### PR TITLE
Add contributing guide and README link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to Zagel
+
+Thanks for helping improve Zagel. The project is early-stage and feedback is
+welcome, especially around UI polish and documentation.
+
+## Quick start
+
+1. Fork the repo and create a topic branch.
+2. Install a recent Rust toolchain (`stable`) and `cargo`.
+3. Run the app locally:
+
+```bash
+cargo run
+```
+
+## Linting (required)
+
+Run clippy with warnings as errors before opening a PR:
+
+```bash
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+If you have it configured, `cargo clippy-strict` is equivalent.
+
+## Tests
+
+If your change adds logic, run:
+
+```bash
+cargo test
+```
+
+## Docs and UX updates
+
+Documentation and UI improvements are welcome. If you change user-facing
+behavior or the UI, update `README.md` and screenshots as needed.
+
+## PR checklist
+
+- Keep the scope focused and explain the motivation.
+- Note any manual testing performed.
+- Confirm clippy passes.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Zagel
 
-Zagel is a cross-platform, GUI REST workbench built with Rust + `iced`. It scans your workspace for request collections (`.http`) and environments (`.env`), lets you pick a request, edit it, and send it.
+Zagel is a cross-platform, GUI REST workbench built with Rust + `iced`. It scans your workspace for request collections (`.http`) and environments (`.env`), lets you pick a request, edit it, and send it. Think of it as a workspace-native alternative to Postman or Insomnia for teams that already keep requests in `.http` files.
 
 The UI is still rough around the edges but it's functioning with good keyboard shortcuts.
 <img width="2468" height="1440" alt="image" src="https://github.com/user-attachments/assets/962da7f6-1933-45c1-9a77-0f1181732147" />
@@ -73,3 +73,7 @@ Supported keys:
 - `env_root` (directory to scan for `*.env`, defaults to `http_root`)
 - `polling_interval_secs` (default `2`)
 - `scan_depth` (default `6`)
+
+## Contributing
+
+Contributions are welcome. See `CONTRIBUTING.md` for setup, linting, and the suggested workflow.


### PR DESCRIPTION
## Summary
- add a contribution guide with setup, linting, and testing notes
- link the guide from the README and expand the project description

Fixes #7