### PR TITLE
Add do,undo stack for ctrl+z hotkey

### DIFF
--- a/src/app/hotkeys.rs
+++ b/src/app/hotkeys.rs
@@ -8,6 +8,12 @@ pub fn subscription() -> Subscription<Message> {
             keyboard::Key::Character(c) if c.eq_ignore_ascii_case("s") && modifiers.command() => {
                 Some(Message::Save)
             }
+            keyboard::Key::Character(c) if c.eq_ignore_ascii_case("z") && modifiers.command() && modifiers.shift() => {
+                Some(Message::Redo)
+            }
+            keyboard::Key::Character(c) if c.eq_ignore_ascii_case("z") && modifiers.command() => {
+                Some(Message::Undo)
+            }
             keyboard::Key::Named(keyboard::key::Named::Enter) if modifiers.command() => {
                 Some(Message::Send)
             }

--- a/src/app/messages.rs
+++ b/src/app/messages.rs
@@ -39,4 +39,6 @@ pub enum Message {
     BuilderPaneResized(pane_grid::ResizeEvent),
     ToggleCollection(String),
     AddRequest,
+    Undo,
+    Redo,
 }


### PR DESCRIPTION
* Used two stacks for implementing undo/redo for changes in [request , header_rows , body ] 
* add two key modifiers ctrl + z --> undo , ctrl + shift + z --> redo

this fixes #4  