### PR TITLE
Add UI automation scenarios and CI e2e coverage

### DIFF
--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -1,0 +1,42 @@
+name: Setup Linux Rust build environment
+description: Install Rust toolchain, cache, and Linux system dependencies
+inputs:
+  extra-packages:
+    description: Optional extra apt packages (space separated)
+    required: false
+    default: ""
+runs:
+  using: composite
+  steps:
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Rust cache
+      uses: Swatinem/rust-cache@v2
+
+    - name: Linux system dependencies
+      shell: bash
+      run: |
+        set -euo pipefail
+        packages=(
+          pkg-config
+          libudev-dev
+          libx11-dev
+          libxrandr-dev
+          libxinerama-dev
+          libxcursor-dev
+          libxi-dev
+          libxkbcommon-dev
+          libwayland-dev
+          libxcb-shape0-dev
+          libxcb-xfixes0-dev
+        )
+
+        extra='${{ inputs.extra-packages }}'
+        if [ -n "$extra" ]; then
+          read -r -a extra_packages <<< "$extra"
+          packages+=("${extra_packages[@]}")
+        fi
+
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends "${packages[@]}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [macos-latest, windows-latest]
 
     steps:
       - name: Checkout
@@ -47,10 +47,47 @@ jobs:
       - name: Test
         run: cargo test --locked
 
+  build-test-linux:
+    name: Build and test (ubuntu-latest)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            pkg-config \
+            libudev-dev \
+            libx11-dev \
+            libxrandr-dev \
+            libxinerama-dev \
+            libxcursor-dev \
+            libxi-dev \
+            libxkbcommon-dev \
+            libwayland-dev \
+            libxcb-shape0-dev \
+            libxcb-xfixes0-dev
+
+      - name: Build
+        run: cargo build --release --locked
+
+      - name: Test
+        run: cargo test --locked
+
   e2e-automation:
     name: Automation E2E (Linux)
     runs-on: ubuntu-latest
-    needs: build-test
+    needs: build-test-linux
+    timeout-minutes: 20
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
             libxcursor-dev \
             libxi-dev \
             libxkbcommon-dev \
+            libxkbcommon-x11-0 \
             libwayland-dev \
             libxcb-shape0-dev \
             libxcb-xfixes0-dev \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,48 @@ jobs:
 
       - name: Test
         run: cargo test --locked
+
+  e2e-automation:
+    name: Automation E2E (Linux)
+    runs-on: ubuntu-latest
+    needs: build-test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            pkg-config \
+            libudev-dev \
+            libx11-dev \
+            libxrandr-dev \
+            libxinerama-dev \
+            libxcursor-dev \
+            libxi-dev \
+            libxkbcommon-dev \
+            libwayland-dev \
+            libxcb-shape0-dev \
+            libxcb-xfixes0-dev \
+            xvfb
+
+      - name: Run automation e2e tests
+        run: |
+          mkdir -p artifacts/e2e
+          xvfb-run -a env ZAGEL_E2E=1 ZAGEL_E2E_ARTIFACTS_DIR=artifacts/e2e cargo test --locked --test e2e_automation -- --nocapture
+
+      - name: Upload automation artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: automation-e2e-artifacts
+          path: artifacts/e2e
+          if-no-files-found: warn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Run automation e2e tests
         run: |
           mkdir -p artifacts/e2e
-          xvfb-run -a env ZAGEL_E2E=1 ZAGEL_E2E_ARTIFACTS_DIR=artifacts/e2e cargo test --locked --test e2e_automation -- --nocapture
+          xvfb-run -a env ZAGEL_E2E=1 ZAGEL_E2E_ARTIFACTS_DIR=artifacts/e2e cargo test --locked --test e2e_automation -- --nocapture --test-threads=1
 
       - name: Upload automation artifacts
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,23 +24,6 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Linux system dependencies
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            pkg-config \
-            libudev-dev \
-            libx11-dev \
-            libxrandr-dev \
-            libxinerama-dev \
-            libxcursor-dev \
-            libxi-dev \
-            libxkbcommon-dev \
-            libwayland-dev \
-            libxcb-shape0-dev \
-            libxcb-xfixes0-dev
-
       - name: Build
         run: cargo build --release --locked
 
@@ -55,27 +38,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v2
-
-      - name: Linux system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            pkg-config \
-            libudev-dev \
-            libx11-dev \
-            libxrandr-dev \
-            libxinerama-dev \
-            libxcursor-dev \
-            libxi-dev \
-            libxkbcommon-dev \
-            libwayland-dev \
-            libxcb-shape0-dev \
-            libxcb-xfixes0-dev
+      - name: Setup Linux build environment
+        uses: ./.github/actions/setup-linux
 
       - name: Build
         run: cargo build --release --locked
@@ -93,29 +57,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v2
-
-      - name: Linux system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            pkg-config \
-            libudev-dev \
-            libx11-dev \
-            libxrandr-dev \
-            libxinerama-dev \
-            libxcursor-dev \
-            libxi-dev \
-            libxkbcommon-dev \
-            libxkbcommon-x11-0 \
-            libwayland-dev \
-            libxcb-shape0-dev \
-            libxcb-xfixes0-dev \
-            xvfb
+      - name: Setup Linux build environment
+        uses: ./.github/actions/setup-linux
+        with:
+          extra-packages: libxkbcommon-x11-0 xvfb
 
       - name: Run automation e2e tests
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6046,6 +6046,7 @@ dependencies = [
  "futures",
  "iced",
  "iced_highlighter",
+ "image",
  "notify",
  "reqwest",
  "scraper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ notify = "8.2.0"
 scraper = "0.20"
 ego-tree = "0.6"
 vec1 = "1.12.1"
+image = { version = "0.25.9", default-features = false, features = ["png"] }
 
 [dev-dependencies]
 tempfile = "3.12.0"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,46 @@ Download a prebuilt binary from GitHub Releases (recommended), or build from sou
 cargo run
 ```
 
+### Automation mode (UI actions + screenshots)
+
+You can run scripted UI flows for repeatable testing and screenshot capture:
+
+```bash
+cargo run -- \
+  --state-file ./.tmp/zagel-state.toml \
+  --project-root ./tests/ui/fixtures/workspace \
+  --automation ./tests/ui/scenarios/smoke.toml \
+  --screenshot-dir ./artifacts/ui \
+  --automation-state-out ./artifacts/ui/state.json \
+  --exit-when-done
+```
+
+When `--automation-state-out` is provided, Zagel writes a full JSON snapshot of
+runtime/app/workspace state at the end of the run (both success and failure), so
+E2E tests can assert behavior without parsing logs.
+
+Supported scenario actions:
+- `select_request` (`value = "relative/path.http#0"`)
+- `send`
+- `wait_for_status` (`value = 200` or `"200"`)
+- `wait_for_text` (`value = "Received response"`)
+- `wait_for_millis` (`value = 1000`)
+- `screenshot` (`value = "after-send"`)
+
+Each action is declared as a `[[step]]` block in TOML.
+
+Bundled scenarios in `tests/ui/scenarios/`:
+- `smoke.toml`: basic selection, send, and screenshot flow
+- `ui_navigation.toml`: selection + ready-state screenshots (no network dependency)
+- `rest_send_status.toml`: send + `wait_for_status` + body text assertion
+- `snapshot_only.toml`: minimal flow for state snapshot generation
+
+Run E2E automation test locally (opt-in):
+
+```bash
+ZAGEL_E2E=1 cargo test --test e2e_automation -- --nocapture
+```
+
 Release build:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ Each action is declared as a `[[step]]` block in TOML.
 Bundled scenarios in `tests/ui/scenarios/`:
 - `smoke.toml`: basic selection, send, and screenshot flow
 - `ui_navigation.toml`: selection + ready-state screenshots (no network dependency)
-- `rest_send_status.toml`: send + `wait_for_status` + body text assertion
+- `rest_send_status.toml`: send + `wait_for_status` + body text assertion against a local test stub
 - `snapshot_only.toml`: minimal flow for state snapshot generation
 
 Run E2E automation test locally (opt-in):
 
 ```bash
-ZAGEL_E2E=1 cargo test --test e2e_automation -- --nocapture
+ZAGEL_E2E=1 ZAGEL_E2E_ARTIFACTS_DIR=artifacts/e2e cargo test --locked --test e2e_automation -- --nocapture
 ```
 
 Release build:

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Bundled scenarios in `tests/ui/scenarios/`:
 Run E2E automation test locally (opt-in):
 
 ```bash
-ZAGEL_E2E=1 ZAGEL_E2E_ARTIFACTS_DIR=artifacts/e2e cargo test --locked --test e2e_automation -- --nocapture
+ZAGEL_E2E=1 ZAGEL_E2E_ARTIFACTS_DIR=artifacts/e2e cargo test --locked --test e2e_automation -- --nocapture --test-threads=1
 ```
 
 Release build:

--- a/src/app/automation.rs
+++ b/src/app/automation.rs
@@ -1,0 +1,840 @@
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use iced::{Subscription, Task, time, window};
+use image::RgbaImage;
+use serde::{Deserialize, Serialize};
+
+use crate::launch::AutomationOptions;
+use crate::model::RequestId;
+
+use super::{Message, Zagel};
+
+const WAIT_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const DEFAULT_WAIT_TIMEOUT_MS: u64 = 20_000;
+
+#[derive(Debug, Clone)]
+pub(super) struct AutomationRuntime {
+    scenario_name: String,
+    steps: Vec<ScenarioStep>,
+    current_step: usize,
+    pending_wait: Option<PendingWait>,
+    pending_screenshot_name: Option<String>,
+    screenshot_dir: PathBuf,
+    state_output_path: Option<PathBuf>,
+    window_id: Option<window::Id>,
+    exit_when_done: bool,
+    done: bool,
+}
+
+impl AutomationRuntime {
+    pub(super) fn load(options: AutomationOptions) -> Result<Self, String> {
+        let scenario_path = options.scenario_path;
+        let raw = fs::read_to_string(&scenario_path)
+            .map_err(|err| format!("failed to read scenario {}: {err}", scenario_path.display()))?;
+        let parsed: ScenarioFile = toml::from_str(&raw).map_err(|err| {
+            format!(
+                "failed to parse scenario {}: {err}",
+                scenario_path.display()
+            )
+        })?;
+
+        let mut all_steps = parsed.step;
+        all_steps.extend(parsed.steps);
+        if all_steps.is_empty() {
+            return Err(format!(
+                "scenario {} has no [[step]] entries",
+                scenario_path.display()
+            ));
+        }
+
+        let mut steps = Vec::with_capacity(all_steps.len());
+        for (index, raw_step) in all_steps.iter().enumerate() {
+            steps.push(ScenarioStep::from_raw(raw_step).map_err(|err| {
+                format!(
+                    "invalid scenario step #{index} in {}: {err}",
+                    scenario_path.display()
+                )
+            })?);
+        }
+
+        fs::create_dir_all(&options.screenshot_dir).map_err(|err| {
+            format!(
+                "failed to create screenshot directory {}: {err}",
+                options.screenshot_dir.display()
+            )
+        })?;
+
+        if let Some(state_path) = options.state_output_path.as_ref()
+            && let Some(parent) = state_path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            fs::create_dir_all(parent).map_err(|err| {
+                format!(
+                    "failed to create state output directory {}: {err}",
+                    parent.display()
+                )
+            })?;
+        }
+
+        let scenario_name = parsed.name.unwrap_or_else(|| {
+            scenario_path
+                .file_stem()
+                .and_then(OsStr::to_str)
+                .map_or_else(|| "scenario".to_string(), str::to_owned)
+        });
+
+        Ok(Self {
+            scenario_name,
+            steps,
+            current_step: 0,
+            pending_wait: None,
+            pending_screenshot_name: None,
+            screenshot_dir: options.screenshot_dir,
+            state_output_path: options.state_output_path,
+            window_id: None,
+            exit_when_done: options.exit_when_done,
+            done: false,
+        })
+    }
+
+    const fn should_poll(&self) -> bool {
+        self.pending_wait.is_some() && !self.done
+    }
+}
+
+#[derive(Debug, Clone)]
+enum ScenarioStep {
+    SelectRequest {
+        selector: RequestSelector,
+        timeout: Duration,
+    },
+    Send,
+    WaitForStatus {
+        status: u16,
+        timeout: Duration,
+    },
+    WaitForText {
+        text: String,
+        timeout: Duration,
+    },
+    WaitForMillis(Duration),
+    Screenshot {
+        name: String,
+    },
+}
+
+impl ScenarioStep {
+    fn from_raw(raw: &RawStep) -> Result<Self, String> {
+        let timeout = Duration::from_millis(raw.timeout_ms.unwrap_or(DEFAULT_WAIT_TIMEOUT_MS));
+        match raw.action.trim().to_ascii_lowercase().as_str() {
+            "select_request" => {
+                let value = raw.required_string("select_request")?;
+                let selector = RequestSelector::parse(value)?;
+                Ok(Self::SelectRequest { selector, timeout })
+            }
+            "send" => Ok(Self::Send),
+            "wait_for_status" => {
+                let value = raw.required_string("wait_for_status")?;
+                let status = value
+                    .parse::<u16>()
+                    .map_err(|_| format!("invalid status code '{value}'"))?;
+                Ok(Self::WaitForStatus { status, timeout })
+            }
+            "wait_for_text" => {
+                let text = raw.required_string("wait_for_text")?.to_string();
+                Ok(Self::WaitForText { text, timeout })
+            }
+            "wait_for_millis" => {
+                let millis = raw.required_u64("wait_for_millis")?;
+                Ok(Self::WaitForMillis(Duration::from_millis(millis)))
+            }
+            "screenshot" => {
+                let name = raw.required_string("screenshot")?.to_string();
+                Ok(Self::Screenshot { name })
+            }
+            other => Err(format!("unsupported action '{other}'")),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+enum PendingWait {
+    RequestAvailable {
+        selector: RequestSelector,
+        started: Instant,
+        timeout: Duration,
+    },
+    ResponseStatus {
+        status: u16,
+        started: Instant,
+        timeout: Duration,
+    },
+    TextPresent {
+        text: String,
+        started: Instant,
+        timeout: Duration,
+    },
+    Delay {
+        started: Instant,
+        duration: Duration,
+    },
+}
+
+#[derive(Debug, Clone)]
+struct RequestSelector {
+    path: PathBuf,
+    index: usize,
+}
+
+impl RequestSelector {
+    fn parse(raw: &str) -> Result<Self, String> {
+        let Some((path, index)) = raw.rsplit_once('#') else {
+            return Err(format!("request selector '{raw}' must be '<path>#<index>'"));
+        };
+        if path.trim().is_empty() {
+            return Err("request selector path cannot be empty".to_string());
+        }
+        let index = index
+            .parse::<usize>()
+            .map_err(|_| format!("invalid request index '{index}'"))?;
+        Ok(Self {
+            path: PathBuf::from(path),
+            index,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ScenarioFile {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    step: Vec<RawStep>,
+    #[serde(default)]
+    steps: Vec<RawStep>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RawStep {
+    action: String,
+    value: Option<StepValue>,
+    timeout_ms: Option<u64>,
+}
+
+impl RawStep {
+    fn required_string(&self, action: &str) -> Result<&str, String> {
+        match self.value.as_ref() {
+            Some(StepValue::Text(text)) if !text.trim().is_empty() => Ok(text),
+            Some(StepValue::Integer(number)) => Err(format!(
+                "action '{action}' expects a string value, got {number}"
+            )),
+            Some(StepValue::Text(_)) | None => {
+                Err(format!("action '{action}' requires a non-empty value"))
+            }
+        }
+    }
+
+    fn required_u64(&self, action: &str) -> Result<u64, String> {
+        match self.value.as_ref() {
+            Some(StepValue::Integer(number)) => Ok(*number),
+            Some(StepValue::Text(text)) => text
+                .parse::<u64>()
+                .map_err(|_| format!("action '{action}' value '{text}' is not a valid number")),
+            None => Err(format!("action '{action}' requires a numeric value")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+enum StepValue {
+    Text(String),
+    Integer(u64),
+}
+
+#[derive(Debug, Clone)]
+enum SnapshotOutcome {
+    Completed,
+    Failed(String),
+}
+
+#[derive(Debug, Serialize)]
+struct AutomationStateSnapshot {
+    scenario_name: String,
+    outcome: String,
+    failure_reason: Option<String>,
+    progress: SnapshotProgress,
+    status_line: String,
+    selected_request: Option<SelectedRequestSnapshot>,
+    request_mode: String,
+    response_display: String,
+    response_tab: String,
+    active_environment: Option<String>,
+    project_roots: Vec<String>,
+    global_env_roots: Vec<String>,
+    environments: Vec<EnvironmentSnapshot>,
+    draft: RequestDraftSnapshot,
+    graphql_query: String,
+    graphql_variables: String,
+    header_rows: Vec<HeaderRowSnapshot>,
+    response_viewer: String,
+    response: Option<ResponseSnapshot>,
+    collections: Vec<HttpFileSnapshot>,
+}
+
+#[derive(Debug, Serialize)]
+struct SnapshotProgress {
+    current_step: usize,
+    total_steps: usize,
+    done: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct SelectedRequestSnapshot {
+    path: String,
+    index: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct RequestDraftSnapshot {
+    title: String,
+    method: String,
+    url: String,
+    headers: String,
+    body: String,
+}
+
+#[derive(Debug, Serialize)]
+struct HeaderRowSnapshot {
+    name: String,
+    value: String,
+}
+
+#[derive(Debug, Serialize)]
+struct EnvironmentSnapshot {
+    name: String,
+    scope: String,
+    vars: std::collections::BTreeMap<String, String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ResponseSnapshot {
+    status: Option<u16>,
+    duration_ms: Option<u128>,
+    error: Option<String>,
+    headers: Vec<(String, String)>,
+    body_raw: String,
+    body_pretty: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct HttpFileSnapshot {
+    path: String,
+    requests: Vec<RequestDraftSnapshot>,
+}
+
+fn sanitize_screenshot_name(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    for ch in name.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+            out.push(ch);
+        } else {
+            out.push('-');
+        }
+    }
+    let trimmed = out.trim_matches('-');
+    if trimmed.is_empty() {
+        "shot".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn immediate(message: Message) -> Task<Message> {
+    Task::perform(async move { message }, |message| message)
+}
+
+fn save_png(path: &Path, screenshot: window::Screenshot) -> Result<(), String> {
+    let window::Screenshot { rgba, size, .. } = screenshot;
+    let Some(image) = RgbaImage::from_raw(size.width, size.height, rgba.to_vec()) else {
+        return Err("screenshot buffer has unexpected size".to_string());
+    };
+    image
+        .save(path)
+        .map_err(|err| format!("failed to save {}: {err}", path.display()))
+}
+
+fn snapshot_request_draft(draft: &crate::model::RequestDraft) -> RequestDraftSnapshot {
+    RequestDraftSnapshot {
+        title: draft.title.clone(),
+        method: draft.method.as_str().to_string(),
+        url: draft.url.clone(),
+        headers: draft.headers.clone(),
+        body: draft.body.clone(),
+    }
+}
+
+const fn environment_scope_label(scope: &crate::model::EnvironmentScope) -> &'static str {
+    match scope {
+        crate::model::EnvironmentScope::Project(_) => "project",
+        crate::model::EnvironmentScope::Global => "global",
+        crate::model::EnvironmentScope::Default => "default",
+    }
+}
+
+fn outcome_details(outcome: &SnapshotOutcome) -> (&'static str, Option<String>) {
+    match outcome {
+        SnapshotOutcome::Completed => ("completed", None),
+        SnapshotOutcome::Failed(reason) => ("failed", Some(reason.clone())),
+    }
+}
+
+impl Zagel {
+    pub(super) fn automation_subscription(&self) -> Option<Subscription<Message>> {
+        self.automation.as_ref().and_then(|runtime| {
+            if runtime.should_poll() {
+                Some(time::every(WAIT_POLL_INTERVAL).map(|_| Message::AutomationPoll))
+            } else {
+                None
+            }
+        })
+    }
+
+    pub(super) fn automation_start_task(&self) -> Task<Message> {
+        if self.automation.is_some() {
+            immediate(Message::AutomationStart)
+        } else {
+            Task::none()
+        }
+    }
+
+    pub(super) fn automation_pulse_task(&self) -> Task<Message> {
+        self.automation
+            .as_ref()
+            .filter(|runtime| !runtime.done)
+            .map_or_else(Task::none, |_| immediate(Message::AutomationPoll))
+    }
+
+    pub(super) fn handle_automation_pulse(&mut self) -> Task<Message> {
+        let Some(mut runtime) = self.automation.take() else {
+            return Task::none();
+        };
+
+        let task = self.drive_automation(&mut runtime);
+        self.automation = Some(runtime);
+        task
+    }
+
+    pub(super) fn handle_automation_window_resolved(
+        &mut self,
+        window_id: Option<window::Id>,
+    ) -> Task<Message> {
+        let Some(mut runtime) = self.automation.take() else {
+            return Task::none();
+        };
+
+        if let Some(window_id) = window_id {
+            runtime.window_id = Some(window_id);
+        }
+
+        let task = if runtime.done && runtime.exit_when_done {
+            runtime
+                .window_id
+                .map_or_else(Task::none, window::close::<Message>)
+        } else {
+            self.drive_automation(&mut runtime)
+        };
+        self.automation = Some(runtime);
+        task
+    }
+
+    pub(super) fn handle_automation_screenshot(
+        &mut self,
+        screenshot: window::Screenshot,
+    ) -> Task<Message> {
+        let Some(mut runtime) = self.automation.take() else {
+            return Task::none();
+        };
+
+        let task = if let Some(name) = runtime.pending_screenshot_name.take() {
+            let stem = sanitize_screenshot_name(&name);
+            let path = runtime
+                .screenshot_dir
+                .join(format!("{:02}-{stem}.png", runtime.current_step + 1));
+            match save_png(&path, screenshot) {
+                Ok(()) => {
+                    runtime.current_step += 1;
+                    self.update_status_with_missing(&format!(
+                        "Automation screenshot saved: {}",
+                        path.display()
+                    ));
+                    self.drive_automation(&mut runtime)
+                }
+                Err(err) => self.fail_automation(&mut runtime, &err),
+            }
+        } else {
+            self.fail_automation(
+                &mut runtime,
+                "received a screenshot but no screenshot step is pending",
+            )
+        };
+
+        self.automation = Some(runtime);
+        task
+    }
+
+    fn write_automation_state_snapshot(
+        &self,
+        runtime: &AutomationRuntime,
+        outcome: &SnapshotOutcome,
+    ) -> Result<Option<PathBuf>, String> {
+        let Some(path) = runtime.state_output_path.as_ref() else {
+            return Ok(None);
+        };
+
+        let snapshot = self.build_automation_state_snapshot(runtime, outcome);
+        let json = serde_json::to_string_pretty(&snapshot)
+            .map_err(|err| format!("failed to serialize automation state snapshot: {err}"))?;
+        fs::write(path, json)
+            .map_err(|err| format!("failed to write automation state {}: {err}", path.display()))?;
+        Ok(Some(path.clone()))
+    }
+
+    fn build_automation_state_snapshot(
+        &self,
+        runtime: &AutomationRuntime,
+        outcome: &SnapshotOutcome,
+    ) -> AutomationStateSnapshot {
+        let (outcome, failure_reason) = outcome_details(outcome);
+        let selected_request = self.workspace.selection().map(|selection| match selection {
+            RequestId::HttpFile { path, index } => SelectedRequestSnapshot {
+                path: path.display().to_string(),
+                index: *index,
+            },
+        });
+        let active_environment = self
+            .environments
+            .get(self.active_environment)
+            .map(|environment| environment.name.clone());
+        let environments = self
+            .environments
+            .iter()
+            .map(|environment| EnvironmentSnapshot {
+                name: environment.name.clone(),
+                scope: environment_scope_label(&environment.scope).to_string(),
+                vars: environment.vars.clone(),
+            })
+            .collect();
+        let response = self.response.as_ref().map(|response| ResponseSnapshot {
+            status: response.preview.status,
+            duration_ms: response
+                .preview
+                .duration
+                .map(|duration| duration.as_millis()),
+            error: response.preview.error.clone(),
+            headers: response.preview.headers.clone(),
+            body_raw: response.body.raw().to_string(),
+            body_pretty: response.body.pretty_text().map(str::to_owned),
+        });
+
+        let mut ordered_paths = self.workspace.http_file_order().clone();
+        let mut additional_paths = self
+            .workspace
+            .http_files()
+            .keys()
+            .filter(|path| !ordered_paths.contains(path))
+            .cloned()
+            .collect::<Vec<_>>();
+        additional_paths
+            .sort_by(|left, right| left.to_string_lossy().cmp(&right.to_string_lossy()));
+        ordered_paths.extend(additional_paths);
+
+        let collections = ordered_paths
+            .into_iter()
+            .filter_map(|path| {
+                self.workspace
+                    .http_files()
+                    .get(&path)
+                    .map(|file| HttpFileSnapshot {
+                        path: file.path.display().to_string(),
+                        requests: file.requests.iter().map(snapshot_request_draft).collect(),
+                    })
+            })
+            .collect();
+
+        AutomationStateSnapshot {
+            scenario_name: runtime.scenario_name.clone(),
+            outcome: outcome.to_string(),
+            failure_reason,
+            progress: SnapshotProgress {
+                current_step: runtime.current_step,
+                total_steps: runtime.steps.len(),
+                done: runtime.done,
+            },
+            status_line: self.status_line.clone(),
+            selected_request,
+            request_mode: self.mode.to_string(),
+            response_display: self.response_display.to_string(),
+            response_tab: self.response_tab.to_string(),
+            active_environment,
+            project_roots: self
+                .project_roots()
+                .iter()
+                .map(|root| root.as_path().display().to_string())
+                .collect(),
+            global_env_roots: self
+                .global_env_roots()
+                .iter()
+                .map(|root| root.as_path().display().to_string())
+                .collect(),
+            environments,
+            draft: snapshot_request_draft(&self.draft),
+            graphql_query: self.graphql_query.text(),
+            graphql_variables: self.graphql_variables.text(),
+            header_rows: self
+                .header_rows
+                .iter()
+                .map(|row| HeaderRowSnapshot {
+                    name: row.name.clone(),
+                    value: row.value.clone(),
+                })
+                .collect(),
+            response_viewer: self.response_viewer.text(),
+            response,
+            collections,
+        }
+    }
+
+    fn wait_satisfied(&self, wait: &PendingWait) -> bool {
+        match wait {
+            PendingWait::RequestAvailable { selector, .. } => {
+                self.resolve_request_selector(selector).is_some()
+            }
+            PendingWait::ResponseStatus { status, .. } => self
+                .response
+                .as_ref()
+                .and_then(|response| response.preview.status)
+                .is_some_and(|actual| actual == *status),
+            PendingWait::TextPresent { text, .. } => {
+                self.status_line.contains(text)
+                    || self
+                        .response
+                        .as_ref()
+                        .is_some_and(|response| response.body.raw().contains(text))
+                    || self.response_viewer.text().contains(text)
+            }
+            PendingWait::Delay { started, duration } => started.elapsed() >= *duration,
+        }
+    }
+
+    fn wait_timeout_message(wait: &PendingWait) -> Option<String> {
+        match wait {
+            PendingWait::RequestAvailable {
+                selector,
+                started,
+                timeout,
+            } if started.elapsed() > *timeout => Some(format!(
+                "timed out waiting for request {}#{}",
+                selector.path.display(),
+                selector.index
+            )),
+            PendingWait::ResponseStatus {
+                status,
+                started,
+                timeout,
+            } if started.elapsed() > *timeout => {
+                Some(format!("timed out waiting for HTTP status {status}"))
+            }
+            PendingWait::TextPresent {
+                text,
+                started,
+                timeout,
+            } if started.elapsed() > *timeout => {
+                Some(format!("timed out waiting for text '{text}'"))
+            }
+            PendingWait::Delay { .. }
+            | PendingWait::RequestAvailable { .. }
+            | PendingWait::ResponseStatus { .. }
+            | PendingWait::TextPresent { .. } => None,
+        }
+    }
+
+    fn resolve_request_selector(&self, selector: &RequestSelector) -> Option<RequestId> {
+        let mut candidates = self
+            .workspace
+            .http_files()
+            .iter()
+            .filter(|(path, _)| {
+                if selector.path.is_absolute() {
+                    *path == &selector.path
+                } else {
+                    path.ends_with(&selector.path)
+                        || self
+                            .project_root_for_path(path)
+                            .and_then(|root| path.strip_prefix(root.as_path()).ok())
+                            .is_some_and(|relative| relative == selector.path)
+                }
+            })
+            .collect::<Vec<_>>();
+
+        candidates
+            .sort_by(|(left, _), (right, _)| left.to_string_lossy().cmp(&right.to_string_lossy()));
+
+        candidates.into_iter().find_map(|(path, file)| {
+            (selector.index < file.requests.len()).then(|| RequestId::HttpFile {
+                path: path.clone(),
+                index: selector.index,
+            })
+        })
+    }
+
+    fn complete_automation(&mut self, runtime: &mut AutomationRuntime) -> Task<Message> {
+        runtime.done = true;
+        self.update_status_with_missing(&format!(
+            "Automation '{}' completed",
+            runtime.scenario_name
+        ));
+        let state_path =
+            match self.write_automation_state_snapshot(runtime, &SnapshotOutcome::Completed) {
+                Ok(path) => path,
+                Err(err) => {
+                    eprintln!("automation: {err}");
+                    None
+                }
+            };
+        if let Some(path) = state_path {
+            self.update_status_with_missing(&format!(
+                "Automation '{}' completed (state: {})",
+                runtime.scenario_name,
+                path.display()
+            ));
+        }
+        if runtime.exit_when_done {
+            runtime.window_id.map_or_else(
+                || window::latest().map(Message::AutomationWindowResolved),
+                window::close::<Message>,
+            )
+        } else {
+            Task::none()
+        }
+    }
+
+    fn fail_automation(&mut self, runtime: &mut AutomationRuntime, reason: &str) -> Task<Message> {
+        runtime.done = true;
+        self.update_status_with_missing(&format!("Automation failed: {reason}"));
+        let state_path = match self
+            .write_automation_state_snapshot(runtime, &SnapshotOutcome::Failed(reason.to_string()))
+        {
+            Ok(path) => path,
+            Err(err) => {
+                eprintln!("automation: {err}");
+                None
+            }
+        };
+        if let Some(path) = state_path {
+            self.update_status_with_missing(&format!(
+                "Automation failed: {reason} (state: {})",
+                path.display()
+            ));
+        }
+        eprintln!("automation failed: {reason}");
+        if runtime.exit_when_done {
+            runtime.window_id.map_or_else(
+                || window::latest().map(Message::AutomationWindowResolved),
+                window::close::<Message>,
+            )
+        } else {
+            Task::none()
+        }
+    }
+
+    fn drive_automation(&mut self, runtime: &mut AutomationRuntime) -> Task<Message> {
+        if runtime.done {
+            return Task::none();
+        }
+
+        if let Some(wait) = runtime.pending_wait.as_ref() {
+            if self.wait_satisfied(wait) {
+                runtime.pending_wait = None;
+                runtime.current_step += 1;
+            } else if let Some(timeout_message) = Self::wait_timeout_message(wait) {
+                return self.fail_automation(runtime, &timeout_message);
+            } else {
+                return Task::none();
+            }
+        }
+
+        loop {
+            let Some(step) = runtime.steps.get(runtime.current_step).cloned() else {
+                return self.complete_automation(runtime);
+            };
+            match step {
+                ScenarioStep::SelectRequest { selector, timeout } => {
+                    if let Some(id) = self.resolve_request_selector(&selector) {
+                        self.apply_selection(&id);
+                        runtime.current_step += 1;
+                        continue;
+                    }
+                    runtime.pending_wait = Some(PendingWait::RequestAvailable {
+                        selector,
+                        started: Instant::now(),
+                        timeout,
+                    });
+                    return Task::none();
+                }
+                ScenarioStep::Send => {
+                    runtime.current_step += 1;
+                    return immediate(Message::Send);
+                }
+                ScenarioStep::WaitForStatus { status, timeout } => {
+                    let wait = PendingWait::ResponseStatus {
+                        status,
+                        started: Instant::now(),
+                        timeout,
+                    };
+                    if self.wait_satisfied(&wait) {
+                        runtime.current_step += 1;
+                        continue;
+                    }
+                    runtime.pending_wait = Some(wait);
+                    return Task::none();
+                }
+                ScenarioStep::WaitForText { text, timeout } => {
+                    let wait = PendingWait::TextPresent {
+                        text,
+                        started: Instant::now(),
+                        timeout,
+                    };
+                    if self.wait_satisfied(&wait) {
+                        runtime.current_step += 1;
+                        continue;
+                    }
+                    runtime.pending_wait = Some(wait);
+                    return Task::none();
+                }
+                ScenarioStep::WaitForMillis(duration) => {
+                    if duration.is_zero() {
+                        runtime.current_step += 1;
+                        continue;
+                    }
+                    runtime.pending_wait = Some(PendingWait::Delay {
+                        started: Instant::now(),
+                        duration,
+                    });
+                    return Task::none();
+                }
+                ScenarioStep::Screenshot { name } => {
+                    let Some(window_id) = runtime.window_id else {
+                        return window::latest().map(Message::AutomationWindowResolved);
+                    };
+                    runtime.pending_screenshot_name = Some(name);
+                    return window::screenshot(window_id)
+                        .map(Message::AutomationScreenshotCaptured);
+                }
+            }
+        }
+    }
+}

--- a/src/app/automation.rs
+++ b/src/app/automation.rs
@@ -137,10 +137,7 @@ impl ScenarioStep {
             }
             "send" => Ok(Self::Send),
             "wait_for_status" => {
-                let value = raw.required_string("wait_for_status")?;
-                let status = value
-                    .parse::<u16>()
-                    .map_err(|_| format!("invalid status code '{value}'"))?;
+                let status = raw.required_u16("wait_for_status")?;
                 Ok(Self::WaitForStatus { status, timeout })
             }
             "wait_for_text" => {
@@ -245,6 +242,12 @@ impl RawStep {
                 .map_err(|_| format!("action '{action}' value '{text}' is not a valid number")),
             None => Err(format!("action '{action}' requires a numeric value")),
         }
+    }
+
+    fn required_u16(&self, action: &str) -> Result<u16, String> {
+        let value = self.required_u64(action)?;
+        u16::try_from(value)
+            .map_err(|_| format!("action '{action}' value '{value}' is out of range for u16"))
     }
 }
 

--- a/src/app/hotkeys.rs
+++ b/src/app/hotkeys.rs
@@ -1,13 +1,11 @@
-use iced::{Subscription, keyboard};
+use iced::{keyboard, Subscription};
 
 use super::messages::Message;
 
 pub fn subscription() -> Subscription<Message> {
     keyboard::listen().filter_map(|event| match event {
         keyboard::Event::KeyPressed { key, modifiers, .. } => match key {
-            keyboard::Key::Character(c)
-                if c == "?" || (c == "/" && modifiers.shift()) =>
-            {
+            keyboard::Key::Character(c) if c == "?" || (c == "/" && modifiers.shift()) => {
                 Some(Message::ToggleShortcutsHelp)
             }
             keyboard::Key::Character(c) if c.eq_ignore_ascii_case("s") && modifiers.command() => {

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -248,6 +248,7 @@ impl Zagel {
                 Err(err) => {
                     app.update_status_with_missing(&format!("Automation disabled: {err}"));
                     eprintln!("automation: {err}");
+                    std::process::exit(2);
                 }
             }
         }

--- a/src/app/messages.rs
+++ b/src/app/messages.rs
@@ -62,4 +62,8 @@ pub enum Message {
     MoveRequestDown(RequestId),
     AddRequest,
     ToggleShortcutsHelp,
+    AutomationStart,
+    AutomationPoll,
+    AutomationWindowResolved(Option<iced::window::Id>),
+    AutomationScreenshotCaptured(iced::window::Screenshot),
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,3 +1,4 @@
+mod automation;
 mod domain;
 mod headers;
 mod hotkeys;

--- a/src/app/view/response.rs
+++ b/src/app/view/response.rs
@@ -1,9 +1,9 @@
+use ego_tree::NodeRef;
 use iced::widget::text::Wrapping;
 use iced::widget::{button, column, container, pick_list, row, rule, text, text_editor};
 use iced::{Element, Length};
 use iced_highlighter::Theme as HighlightTheme;
 use scraper::{Html, Node};
-use ego_tree::NodeRef;
 
 use super::super::Message;
 use crate::model::ResponsePreview;
@@ -196,7 +196,7 @@ pub fn response_view_toggle(current: ResponseDisplay) -> Element<'static, Messag
 }
 
 /// Creates the main response panel UI element.
-/// 
+///
 /// Displays the HTTP response status, duration, and either the body or headers
 /// based on the selected tab. Supports both raw and pretty-printed views for
 /// JSON and HTML content.
@@ -277,7 +277,7 @@ pub fn response_panel<'a>(
 }
 
 /// Attempts to format a JSON string with proper indentation.
-/// 
+///
 /// Returns `Some(formatted_json)` if the input is valid JSON, otherwise returns `None`.
 pub fn pretty_json(raw: &str) -> Option<String> {
     serde_json::from_str::<serde_json::Value>(raw)
@@ -300,8 +300,8 @@ pub fn pretty_html(raw: &str, mode: HtmlParseMode) -> String {
 
     // List of void/self-closing tags that don't need closing tags
     let void_tags: std::collections::HashSet<&str> = [
-        "area", "base", "br", "col", "embed", "hr", "img", "input",
-        "link", "meta", "param", "source", "track", "wbr",
+        "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param",
+        "source", "track", "wbr",
     ]
     .into_iter()
     .collect();
@@ -309,7 +309,14 @@ pub fn pretty_html(raw: &str, mode: HtmlParseMode) -> String {
     let mut result = String::new();
     match mode {
         HtmlParseMode::Document => {
-            format_node(document.tree.root(), &mut result, 0, &void_tags, false, false);
+            format_node(
+                document.tree.root(),
+                &mut result,
+                0,
+                &void_tags,
+                false,
+                false,
+            );
         }
         HtmlParseMode::Fragment => {
             let raw_has_body_tag = trimmed.to_ascii_lowercase().contains("<body");
@@ -367,7 +374,7 @@ fn format_fragment_root(
 }
 
 /// Recursively formats an HTML node tree with proper indentation.
-/// 
+///
 /// Preserves text content verbatim, especially within preformatted tags (pre, code, etc.).
 /// Only adds newlines and indentation when `should_indent` is true to avoid
 /// forcing formatting on inline-only content.
@@ -388,7 +395,14 @@ fn format_node(
     match node.value() {
         Node::Document | Node::Fragment => {
             for child in node.children() {
-                format_node(child, output, indent, void_tags, in_preformatted, should_indent);
+                format_node(
+                    child,
+                    output,
+                    indent,
+                    void_tags,
+                    in_preformatted,
+                    should_indent,
+                );
             }
         }
         Node::Doctype(doctype) => {
@@ -467,19 +481,38 @@ fn format_node(
             }
 
             let children: Vec<_> = node.children().collect();
-            let has_text_children = children.iter().any(|child| matches!(child.value(), Node::Text(_)));
-            let has_element_children = children.iter().any(|child| matches!(child.value(), Node::Element(_)));
-            let child_should_indent = has_element_children || (has_text_children && children.len() > 1);
+            let has_text_children = children
+                .iter()
+                .any(|child| matches!(child.value(), Node::Text(_)));
+            let has_element_children = children
+                .iter()
+                .any(|child| matches!(child.value(), Node::Element(_)));
+            let child_should_indent =
+                has_element_children || (has_text_children && children.len() > 1);
 
             // Determine if children are in preformatted context
             let child_in_preformatted = in_preformatted || tag_is_preformatted;
 
             for child in children {
                 if child_should_indent {
-                    format_node(child, output, indent + 1, void_tags, child_in_preformatted, child_should_indent);
+                    format_node(
+                        child,
+                        output,
+                        indent + 1,
+                        void_tags,
+                        child_in_preformatted,
+                        child_should_indent,
+                    );
                 } else {
                     // For inline formatting, pass 0 indent but preserve preformatted context
-                    format_node(child, output, 0, void_tags, child_in_preformatted, child_should_indent);
+                    format_node(
+                        child,
+                        output,
+                        0,
+                        void_tags,
+                        child_in_preformatted,
+                        child_should_indent,
+                    );
                 }
             }
 

--- a/src/app/view/response.rs
+++ b/src/app/view/response.rs
@@ -1,6 +1,8 @@
 use ego_tree::NodeRef;
 use iced::widget::text::Wrapping;
-use iced::widget::{button, column, container, pick_list, row, rule, text, text_editor};
+use iced::widget::{
+    button, column, container, pick_list, row, rule, scrollable, text, text_editor,
+};
 use iced::{Element, Length};
 use iced_highlighter::Theme as HighlightTheme;
 use scraper::{Html, Node};
@@ -254,10 +256,12 @@ pub fn response_panel<'a>(
             .spacing(6)
             .into();
 
-            let headers_section: Element<'_, Message> =
-                column![text("Headers").size(14), headers_view.spacing(4),]
-                    .spacing(6)
-                    .into();
+            let headers_section: Element<'_, Message> = column![
+                text("Headers").size(14),
+                scrollable(headers_view.spacing(4)).height(Length::Fill),
+            ]
+            .spacing(6)
+            .into();
 
             let tab_view: Element<'_, Message> = match tab {
                 ResponseTab::Body => body_section,

--- a/src/app/view/workspace.rs
+++ b/src/app/view/workspace.rs
@@ -258,11 +258,7 @@ fn response(app: &Zagel) -> Element<'_, Message> {
             .into(),
     );
 
-    let response_scroll = scrollable(response_section)
-        .width(Length::Fill)
-        .height(Length::Fill);
-
-    let base = container(response_scroll)
+    let base = container(response_section)
         .padding(8)
         .width(Length::Fill)
         .height(Length::Fill)

--- a/src/app/view/workspace.rs
+++ b/src/app/view/workspace.rs
@@ -1,14 +1,13 @@
 use iced::widget::pane_grid::{self, PaneGrid};
 use iced::widget::{
-    button, column, container, pick_list, row, scrollable, stack, text, text_editor,
-    text_input,
+    button, column, container, pick_list, row, scrollable, stack, text, text_editor, text_input,
 };
-use iced::{alignment, Alignment, Element, Length, Theme};
+use iced::{Alignment, Element, Length, Theme, alignment};
 
 use super::super::{Message, Zagel, headers};
-use super::section;
 use super::auth::auth_editor;
 use super::response::{response_panel, response_tab_toggle, response_view_toggle};
+use super::section;
 use crate::app::options::RequestMode;
 use crate::model::{Method, RequestId};
 use crate::theme;
@@ -70,12 +69,12 @@ fn builder(app: &Zagel) -> Element<'_, Message> {
 fn builder_form(app: &Zagel) -> Element<'_, Message> {
     let env_pick = container(
         pick_list(
-        app.environments
-            .iter()
-            .map(|e| e.name.clone())
-            .collect::<Vec<_>>(),
-        Some(app.environments[app.active_environment].name.clone()),
-        Message::EnvironmentChanged,
+            app.environments
+                .iter()
+                .map(|e| e.name.clone())
+                .collect::<Vec<_>>(),
+            Some(app.environments[app.active_environment].name.clone()),
+            Message::EnvironmentChanged,
         )
         .width(Length::Fill),
     )
@@ -84,9 +83,9 @@ fn builder_form(app: &Zagel) -> Element<'_, Message> {
 
     let method_pick = container(
         pick_list(
-        Method::ALL.to_vec(),
-        Some(app.draft.method),
-        Message::MethodSelected,
+            Method::ALL.to_vec(),
+            Some(app.draft.method),
+            Message::MethodSelected,
         )
         .width(Length::Fill),
     )
@@ -125,9 +124,9 @@ fn builder_form(app: &Zagel) -> Element<'_, Message> {
 
     let mode_pick = container(
         pick_list(
-        RequestMode::ALL.to_vec(),
-        Some(app.mode),
-        Message::ModeChanged,
+            RequestMode::ALL.to_vec(),
+            Some(app.mode),
+            Message::ModeChanged,
         )
         .width(Length::Fill),
     )
@@ -197,15 +196,10 @@ fn builder_body(app: &Zagel) -> Element<'_, Message> {
                 text_editor(&app.graphql_variables)
                     .on_action(Message::GraphqlVariablesEdited)
                     .height(Length::FillPortion(2));
-            column![
-                text("Query"),
-                query_editor,
-                text("Variables"),
-                vars_editor,
-            ]
-            .height(Length::Fill)
-            .spacing(6)
-            .into()
+            column![text("Query"), query_editor, text("Variables"), vars_editor,]
+                .height(Length::Fill)
+                .spacing(6)
+                .into()
         }
         RequestMode::Rest => {
             let body_editor: iced::widget::TextEditor<'_, _, _, Theme> =
@@ -243,7 +237,8 @@ fn response(app: &Zagel) -> Element<'_, Message> {
                 .and_then(|response| response.body.pretty_text())
                 .is_some()
         {
-            status_row = status_row.push(button("Copy pretty").on_press(Message::CopyResponsePretty));
+            status_row =
+                status_row.push(button("Copy pretty").on_press(Message::CopyResponsePretty));
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,184 @@
+use std::ffi::OsString;
+use std::fmt::{Display, Formatter};
+use std::io;
+use std::path::PathBuf;
+
+use crate::launch::{AutomationOptions, LaunchOptions};
+
+const DEFAULT_SCREENSHOT_DIR: &str = "artifacts/ui";
+
+#[derive(Debug)]
+pub enum CliError {
+    HelpRequested,
+    MissingValue(&'static str),
+    UnknownFlag(String),
+    NonUtf8Flag,
+    CurrentDirectory(io::Error),
+    MissingAutomationScenario,
+}
+
+impl Display for CliError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::HelpRequested => f.write_str("help requested"),
+            Self::MissingValue(flag) => write!(f, "missing value for {flag}"),
+            Self::UnknownFlag(flag) => write!(f, "unknown flag: {flag}"),
+            Self::NonUtf8Flag => f.write_str("encountered a non-UTF8 argument"),
+            Self::CurrentDirectory(err) => {
+                write!(f, "failed to read current directory: {err}")
+            }
+            Self::MissingAutomationScenario => {
+                f.write_str("automation flags were provided without --automation <scenario.toml>")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CliError {}
+
+pub const fn usage() -> &'static str {
+    "Usage: zagel [OPTIONS]\n\n\
+Options:\n\
+  --state-file <path>          Override persisted state path\n\
+  --project-root <path>        Add project root override (repeatable)\n\
+  --global-env-root <path>     Add global env root override (repeatable)\n\
+  --automation <path>          Run automation scenario from TOML file\n\
+  --screenshot-dir <path>      Output directory for automation screenshots\n\
+  --automation-state-out <path> Write full automation state snapshot (JSON)\n\
+  --exit-when-done             Exit app when automation scenario completes\n\
+  -h, --help                   Show this help\n"
+}
+
+pub fn parse_env() -> Result<LaunchOptions, CliError> {
+    parse_args(std::env::args_os().skip(1))
+}
+
+fn resolve_path(raw: OsString) -> Result<PathBuf, CliError> {
+    let path = PathBuf::from(raw);
+    if path.is_absolute() {
+        Ok(path)
+    } else {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(path))
+            .map_err(CliError::CurrentDirectory)
+    }
+}
+
+fn next_path(
+    iter: &mut impl Iterator<Item = OsString>,
+    flag: &'static str,
+) -> Result<PathBuf, CliError> {
+    let raw = iter.next().ok_or(CliError::MissingValue(flag))?;
+    resolve_path(raw)
+}
+
+pub fn parse_args(args: impl IntoIterator<Item = OsString>) -> Result<LaunchOptions, CliError> {
+    let mut options = LaunchOptions::default();
+    let mut automation_scenario: Option<PathBuf> = None;
+    let mut screenshot_dir: Option<PathBuf> = None;
+    let mut state_output_path: Option<PathBuf> = None;
+    let mut exit_when_done = false;
+
+    let mut iter = args.into_iter();
+    while let Some(raw_flag) = iter.next() {
+        let Some(flag) = raw_flag.to_str() else {
+            return Err(CliError::NonUtf8Flag);
+        };
+
+        match flag {
+            "-h" | "--help" => return Err(CliError::HelpRequested),
+            "--state-file" => {
+                options.state_file = Some(next_path(&mut iter, "--state-file")?);
+            }
+            "--project-root" => {
+                options
+                    .project_roots
+                    .push(next_path(&mut iter, "--project-root")?);
+            }
+            "--global-env-root" => {
+                options
+                    .global_env_roots
+                    .push(next_path(&mut iter, "--global-env-root")?);
+            }
+            "--automation" => {
+                automation_scenario = Some(next_path(&mut iter, "--automation")?);
+            }
+            "--screenshot-dir" => {
+                screenshot_dir = Some(next_path(&mut iter, "--screenshot-dir")?);
+            }
+            "--automation-state-out" => {
+                state_output_path = Some(next_path(&mut iter, "--automation-state-out")?);
+            }
+            "--exit-when-done" => {
+                exit_when_done = true;
+            }
+            _ => {
+                return Err(CliError::UnknownFlag(flag.to_string()));
+            }
+        }
+    }
+
+    if automation_scenario.is_some()
+        || screenshot_dir.is_some()
+        || state_output_path.is_some()
+        || exit_when_done
+    {
+        let scenario_path = automation_scenario.ok_or(CliError::MissingAutomationScenario)?;
+        let screenshot_dir = match screenshot_dir {
+            Some(dir) => dir,
+            None => resolve_path(OsString::from(DEFAULT_SCREENSHOT_DIR))?,
+        };
+        options.automation = Some(AutomationOptions {
+            scenario_path,
+            screenshot_dir,
+            state_output_path,
+            exit_when_done,
+        });
+    }
+
+    Ok(options)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+
+    use super::{CliError, parse_args};
+
+    #[test]
+    fn parses_automation_state_output_flag() {
+        let args = vec![
+            OsString::from("--automation"),
+            OsString::from("./tests/ui/scenarios/smoke.toml"),
+            OsString::from("--automation-state-out"),
+            OsString::from("./artifacts/ui/state.json"),
+            OsString::from("--exit-when-done"),
+        ];
+
+        let parsed = parse_args(args).expect("parse args");
+        let automation = parsed
+            .automation
+            .expect("automation options should be present");
+
+        assert_eq!(
+            automation
+                .state_output_path
+                .expect("state output path should be parsed")
+                .file_name()
+                .and_then(std::ffi::OsStr::to_str),
+            Some("state.json")
+        );
+        assert!(automation.exit_when_done);
+    }
+
+    #[test]
+    fn automation_related_flags_require_automation_scenario() {
+        let args = vec![
+            OsString::from("--automation-state-out"),
+            OsString::from("out.json"),
+        ];
+
+        let err = parse_args(args).expect_err("missing automation scenario should fail");
+        assert!(matches!(err, CliError::MissingAutomationScenario));
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -69,6 +69,9 @@ fn next_path(
     flag: &'static str,
 ) -> Result<PathBuf, CliError> {
     let raw = iter.next().ok_or(CliError::MissingValue(flag))?;
+    if raw.to_str().is_some_and(|value| value.starts_with('-')) {
+        return Err(CliError::MissingValue(flag));
+    }
     resolve_path(raw)
 }
 
@@ -180,5 +183,17 @@ mod tests {
 
         let err = parse_args(args).expect_err("missing automation scenario should fail");
         assert!(matches!(err, CliError::MissingAutomationScenario));
+    }
+
+    #[test]
+    fn missing_value_is_reported_when_next_token_is_a_flag() {
+        let args = vec![
+            OsString::from("--state-file"),
+            OsString::from("--project-root"),
+            OsString::from("./workspace"),
+        ];
+
+        let err = parse_args(args).expect_err("missing value should fail");
+        assert!(matches!(err, CliError::MissingValue("--state-file")));
     }
 }

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -1,0 +1,17 @@
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Default)]
+pub struct LaunchOptions {
+    pub state_file: Option<PathBuf>,
+    pub project_roots: Vec<PathBuf>,
+    pub global_env_roots: Vec<PathBuf>,
+    pub automation: Option<AutomationOptions>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AutomationOptions {
+    pub scenario_path: PathBuf,
+    pub screenshot_dir: PathBuf,
+    pub state_output_path: Option<PathBuf>,
+    pub exit_when_done: bool,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::multiple_crate_versions)]
 
 mod app;
+mod cli;
+mod launch;
 mod model;
 mod net;
 mod parser;
@@ -9,5 +11,25 @@ mod state;
 mod theme;
 
 fn main() -> iced::Result {
-    app::run()
+    let launch = match cli::parse_env() {
+        Ok(launch) => launch,
+        Err(cli::CliError::HelpRequested) => {
+            println!("{}", cli::usage());
+            return Ok(());
+        }
+        Err(err) => {
+            eprintln!("{err}");
+            eprintln!("{}", cli::usage());
+            std::process::exit(2);
+        }
+    };
+
+    if let Some(path) = launch.state_file.clone()
+        && let Err(_existing) = state::set_state_file_override(path)
+    {
+        eprintln!("state file override was already configured");
+        std::process::exit(2);
+    }
+
+    app::run(launch)
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,9 +1,12 @@
 use std::fs;
 use std::path::PathBuf;
+use std::sync::OnceLock;
 
 use serde::{Deserialize, Serialize};
 
 use crate::theme::ThemeChoice;
+
+static STATE_FILE_OVERRIDE: OnceLock<PathBuf> = OnceLock::new();
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AppState {
@@ -55,6 +58,13 @@ impl AppState {
     }
 }
 
+pub fn set_state_file_override(path: PathBuf) -> Result<(), PathBuf> {
+    STATE_FILE_OVERRIDE.set(path)
+}
+
 fn state_file_path() -> Option<PathBuf> {
-    dirs::config_dir().map(|dir| dir.join("zagel").join("state.toml"))
+    STATE_FILE_OVERRIDE
+        .get()
+        .cloned()
+        .or_else(|| dirs::config_dir().map(|dir| dir.join("zagel").join("state.toml")))
 }

--- a/tests/e2e_automation.rs
+++ b/tests/e2e_automation.rs
@@ -1,9 +1,19 @@
 use std::fs;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
+use std::process::{Command, Output, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
 
 use serde::Deserialize;
-use tempfile::{tempdir, TempDir};
+use tempfile::{TempDir, tempdir};
+
+const LOCAL_STUB_ADDR: &str = "127.0.0.1:18080";
+const SCENARIO_TIMEOUT: Duration = Duration::from_secs(60);
+const WAIT_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 #[derive(Debug, Deserialize)]
 struct SnapshotProgress {
@@ -32,6 +42,20 @@ struct ScenarioRunPaths {
     state_file: PathBuf,
     artifacts: PathBuf,
     state_json: PathBuf,
+}
+
+struct LocalStubServer {
+    stop_tx: mpsc::Sender<()>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl Drop for LocalStubServer {
+    fn drop(&mut self) {
+        let _ = self.stop_tx.send(());
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
 }
 
 fn e2e_enabled() -> bool {
@@ -101,7 +125,7 @@ fn run_scenario(
     scenario: &Path,
     paths: &ScenarioRunPaths,
 ) -> Output {
-    Command::new(binary)
+    let mut child = Command::new(binary)
         .current_dir(root)
         .arg("--state-file")
         .arg(&paths.state_file)
@@ -114,13 +138,99 @@ fn run_scenario(
         .arg("--automation-state-out")
         .arg(&paths.state_json)
         .arg("--exit-when-done")
-        .output()
-        .expect("run automation scenario")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn automation scenario");
+
+    let start = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(_status)) => {
+                return child
+                    .wait_with_output()
+                    .expect("collect automation scenario output");
+            }
+            Ok(None) if start.elapsed() >= SCENARIO_TIMEOUT => {
+                let _ = child.kill();
+                let output = child
+                    .wait_with_output()
+                    .expect("collect timed out automation output");
+                panic!(
+                    "automation scenario timed out after {:?}\nstdout:\n{}\nstderr:\n{}",
+                    SCENARIO_TIMEOUT,
+                    String::from_utf8_lossy(&output.stdout),
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+            Ok(None) => thread::sleep(WAIT_POLL_INTERVAL),
+            Err(err) => {
+                let _ = child.kill();
+                panic!("failed to wait for automation scenario: {err}");
+            }
+        }
+    }
 }
 
 fn read_snapshot(path: &Path) -> StateSnapshot {
     serde_json::from_str(&fs::read_to_string(path).expect("read automation state snapshot"))
         .expect("parse automation state snapshot json")
+}
+
+fn handle_local_stub_connection(stream: &mut TcpStream) {
+    let _ = stream.set_read_timeout(Some(Duration::from_millis(500)));
+
+    let mut buffer = [0_u8; 4096];
+    let read = stream.read(&mut buffer).unwrap_or(0);
+    let request = String::from_utf8_lossy(&buffer[..read]);
+    let path = request
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .unwrap_or("/");
+
+    let (status, body) = match path {
+        "/get" => ("200 OK", r#"{"ok":true}"#),
+        "/uuid" => ("200 OK", r#"{"uuid":"local-test-uuid"}"#),
+        _ => ("404 Not Found", r#"{"error":"not found"}"#),
+    };
+
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    let _ = stream.write_all(response.as_bytes());
+    let _ = stream.flush();
+}
+
+fn start_local_stub_server() -> LocalStubServer {
+    let listener = TcpListener::bind(LOCAL_STUB_ADDR)
+        .expect("bind local stub server (port 18080 must be free)");
+    listener
+        .set_nonblocking(true)
+        .expect("set local stub listener non-blocking");
+
+    let (stop_tx, stop_rx) = mpsc::channel::<()>();
+    let handle = thread::spawn(move || {
+        loop {
+            if stop_rx.try_recv().is_ok() {
+                break;
+            }
+
+            match listener.accept() {
+                Ok((mut stream, _addr)) => handle_local_stub_connection(&mut stream),
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(20));
+                }
+                Err(_err) => break,
+            }
+        }
+    });
+
+    LocalStubServer {
+        stop_tx,
+        handle: Some(handle),
+    }
 }
 
 #[test]
@@ -212,4 +322,46 @@ fn snapshot_only_scenario_emits_final_state_without_screenshots() {
         .selected_request
         .expect("snapshot should include selected request");
     assert_eq!(selected.index, 0);
+}
+
+#[test]
+fn rest_send_status_scenario_completes_against_local_stub() {
+    if !e2e_enabled() {
+        eprintln!("skipping UI e2e test (set ZAGEL_E2E=1 to enable)");
+        return;
+    }
+
+    let Some(binary) = binary_path() else {
+        eprintln!("skipping UI e2e test (zagel binary not available in test env)");
+        return;
+    };
+
+    let _stub = start_local_stub_server();
+
+    let root = manifest_path();
+    let fixture_workspace = root.join("tests/ui/fixtures/workspace");
+    let scenario = root.join("tests/ui/scenarios/rest_send_status.toml");
+    let paths = prepare_run_paths("rest_send_status_scenario");
+
+    let output = run_scenario(&binary, &root, &fixture_workspace, &scenario, &paths);
+
+    assert!(
+        output.status.success(),
+        "rest-send-status run should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    require_file(&paths.artifacts.join("05-send-status.png"));
+    require_file(&paths.state_json);
+
+    let snapshot = read_snapshot(&paths.state_json);
+    assert_eq!(snapshot.outcome, "completed");
+    assert_eq!(snapshot.scenario_name, "rest-send-status");
+    assert!(snapshot.progress.done);
+
+    let selected = snapshot
+        .selected_request
+        .expect("snapshot should include selected request");
+    assert_eq!(selected.index, 1);
 }

--- a/tests/e2e_automation.rs
+++ b/tests/e2e_automation.rs
@@ -1,0 +1,215 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use serde::Deserialize;
+use tempfile::{tempdir, TempDir};
+
+#[derive(Debug, Deserialize)]
+struct SnapshotProgress {
+    current_step: usize,
+    total_steps: usize,
+    done: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct SelectedRequest {
+    path: String,
+    index: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct StateSnapshot {
+    scenario_name: String,
+    status_line: String,
+    outcome: String,
+    progress: SnapshotProgress,
+    selected_request: Option<SelectedRequest>,
+}
+
+struct ScenarioRunPaths {
+    _temp: Option<TempDir>,
+    state_file: PathBuf,
+    artifacts: PathBuf,
+    state_json: PathBuf,
+}
+
+fn e2e_enabled() -> bool {
+    std::env::var("ZAGEL_E2E")
+        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+fn binary_path() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_zagel") {
+        return Some(PathBuf::from(path));
+    }
+
+    let mut fallback = manifest_path();
+    fallback.push("target");
+    fallback.push("debug");
+    fallback.push(if cfg!(windows) { "zagel.exe" } else { "zagel" });
+    fallback.exists().then_some(fallback)
+}
+
+fn manifest_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn require_file(path: &Path) {
+    assert!(path.exists(), "expected file to exist: {}", path.display());
+}
+
+fn prepare_run_paths(test_name: &str) -> ScenarioRunPaths {
+    if let Some(base) = std::env::var_os("ZAGEL_E2E_ARTIFACTS_DIR") {
+        let base = PathBuf::from(base).join(test_name);
+        if base.exists() {
+            fs::remove_dir_all(&base).expect("remove previous test artifact directory");
+        }
+        fs::create_dir_all(&base).expect("create test artifact directory");
+
+        let artifacts = base.join("artifacts");
+        fs::create_dir_all(&artifacts).expect("create screenshots artifact directory");
+
+        let state_json = artifacts.join("state.json");
+        let state_file = base.join("state.toml");
+        return ScenarioRunPaths {
+            _temp: None,
+            state_file,
+            artifacts,
+            state_json,
+        };
+    }
+
+    let temp = tempdir().expect("create temp dir for e2e outputs");
+    let state_file = temp.path().join("state.toml");
+    let artifacts = temp.path().join("artifacts");
+    let state_json = artifacts.join("state.json");
+
+    ScenarioRunPaths {
+        _temp: Some(temp),
+        state_file,
+        artifacts,
+        state_json,
+    }
+}
+
+fn run_scenario(
+    binary: &Path,
+    root: &Path,
+    fixture_workspace: &Path,
+    scenario: &Path,
+    paths: &ScenarioRunPaths,
+) -> Output {
+    Command::new(binary)
+        .current_dir(root)
+        .arg("--state-file")
+        .arg(&paths.state_file)
+        .arg("--project-root")
+        .arg(fixture_workspace)
+        .arg("--automation")
+        .arg(scenario)
+        .arg("--screenshot-dir")
+        .arg(&paths.artifacts)
+        .arg("--automation-state-out")
+        .arg(&paths.state_json)
+        .arg("--exit-when-done")
+        .output()
+        .expect("run automation scenario")
+}
+
+fn read_snapshot(path: &Path) -> StateSnapshot {
+    serde_json::from_str(&fs::read_to_string(path).expect("read automation state snapshot"))
+        .expect("parse automation state snapshot json")
+}
+
+#[test]
+fn automation_navigation_scenario_emits_screenshots_and_state() {
+    if !e2e_enabled() {
+        eprintln!("skipping UI e2e test (set ZAGEL_E2E=1 to enable)");
+        return;
+    }
+
+    let Some(binary) = binary_path() else {
+        eprintln!("skipping UI e2e test (zagel binary not available in test env)");
+        return;
+    };
+
+    let root = manifest_path();
+    let fixture_workspace = root.join("tests/ui/fixtures/workspace");
+    let scenario = root.join("tests/ui/scenarios/ui_navigation.toml");
+    let paths = prepare_run_paths("automation_navigation_scenario");
+
+    let output = run_scenario(&binary, &root, &fixture_workspace, &scenario, &paths);
+
+    assert!(
+        output.status.success(),
+        "automation run should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    require_file(&paths.artifacts.join("02-selected.png"));
+    require_file(&paths.artifacts.join("04-ready.png"));
+    require_file(&paths.state_json);
+
+    let snapshot = read_snapshot(&paths.state_json);
+
+    assert_eq!(snapshot.outcome, "completed");
+    assert_eq!(snapshot.scenario_name, "ui-navigation");
+    assert!(snapshot.status_line.contains("completed"));
+    assert_eq!(
+        snapshot.progress.current_step,
+        snapshot.progress.total_steps
+    );
+    assert!(snapshot.progress.done);
+
+    let selected = snapshot
+        .selected_request
+        .expect("snapshot should include selected request");
+    assert!(selected.path.contains("sample.http"));
+    assert_eq!(selected.index, 0);
+}
+
+#[test]
+fn snapshot_only_scenario_emits_final_state_without_screenshots() {
+    if !e2e_enabled() {
+        eprintln!("skipping UI e2e test (set ZAGEL_E2E=1 to enable)");
+        return;
+    }
+
+    let Some(binary) = binary_path() else {
+        eprintln!("skipping UI e2e test (zagel binary not available in test env)");
+        return;
+    };
+
+    let root = manifest_path();
+    let fixture_workspace = root.join("tests/ui/fixtures/workspace");
+    let scenario = root.join("tests/ui/scenarios/snapshot_only.toml");
+    let paths = prepare_run_paths("snapshot_only_scenario");
+
+    let output = run_scenario(&binary, &root, &fixture_workspace, &scenario, &paths);
+
+    assert!(
+        output.status.success(),
+        "snapshot-only run should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    require_file(&paths.state_json);
+
+    let snapshot = read_snapshot(&paths.state_json);
+    assert_eq!(snapshot.outcome, "completed");
+    assert_eq!(snapshot.scenario_name, "snapshot-only");
+    assert!(snapshot.progress.done);
+    assert_eq!(
+        snapshot.progress.current_step,
+        snapshot.progress.total_steps
+    );
+
+    let selected = snapshot
+        .selected_request
+        .expect("snapshot should include selected request");
+    assert_eq!(selected.index, 0);
+}

--- a/tests/ui/fixtures/workspace/requests/sample.http
+++ b/tests/ui/fixtures/workspace/requests/sample.http
@@ -1,0 +1,6 @@
+GET https://httpbin.org/get
+Accept: application/json
+
+###
+GET https://httpbin.org/uuid
+Accept: application/json

--- a/tests/ui/fixtures/workspace/requests/sample.http
+++ b/tests/ui/fixtures/workspace/requests/sample.http
@@ -1,6 +1,6 @@
-GET https://httpbin.org/get
+GET http://127.0.0.1:18080/get
 Accept: application/json
 
 ###
-GET https://httpbin.org/uuid
+GET http://127.0.0.1:18080/uuid
 Accept: application/json

--- a/tests/ui/scenarios/rest_send_status.toml
+++ b/tests/ui/scenarios/rest_send_status.toml
@@ -1,0 +1,23 @@
+name = "rest-send-status"
+
+[[step]]
+action = "select_request"
+value = "requests/sample.http#1"
+timeout_ms = 10000
+
+[[step]]
+action = "send"
+
+[[step]]
+action = "wait_for_status"
+value = 200
+timeout_ms = 30000
+
+[[step]]
+action = "wait_for_text"
+value = "uuid"
+timeout_ms = 30000
+
+[[step]]
+action = "screenshot"
+value = "send-status"

--- a/tests/ui/scenarios/smoke.toml
+++ b/tests/ui/scenarios/smoke.toml
@@ -1,0 +1,21 @@
+name = "smoke"
+
+[[step]]
+action = "select_request"
+value = "requests/sample.http#0"
+timeout_ms = 10000
+
+[[step]]
+action = "screenshot"
+value = "loaded"
+
+[[step]]
+action = "send"
+
+[[step]]
+action = "wait_for_millis"
+value = 1200
+
+[[step]]
+action = "screenshot"
+value = "after-send"

--- a/tests/ui/scenarios/snapshot_only.toml
+++ b/tests/ui/scenarios/snapshot_only.toml
@@ -1,0 +1,10 @@
+name = "snapshot-only"
+
+[[step]]
+action = "select_request"
+value = "requests/sample.http#0"
+timeout_ms = 10000
+
+[[step]]
+action = "wait_for_millis"
+value = 250

--- a/tests/ui/scenarios/ui_navigation.toml
+++ b/tests/ui/scenarios/ui_navigation.toml
@@ -1,0 +1,18 @@
+name = "ui-navigation"
+
+[[step]]
+action = "select_request"
+value = "requests/sample.http#0"
+timeout_ms = 10000
+
+[[step]]
+action = "screenshot"
+value = "selected"
+
+[[step]]
+action = "wait_for_millis"
+value = 200
+
+[[step]]
+action = "screenshot"
+value = "ready"


### PR DESCRIPTION
## Summary
- add a CLI-driven UI automation runner that can execute scenario steps, take screenshots, and write a full end-of-run state snapshot JSON
- add reusable UI fixture scenarios and opt-in e2e automation tests, including assertions for generated screenshots and snapshot content
- add a Linux CI automation e2e job that runs under `xvfb` and uploads generated artifacts for debugging

## Testing
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --locked
- ZAGEL_E2E=1 ZAGEL_E2E_ARTIFACTS_DIR=artifacts/e2e cargo test --locked --test e2e_automation -- --nocapture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end UI automation: scenario-driven steps, conditional waits, screenshot capture, and persisted state snapshots.
  * CLI & launch options to run scenarios, set project roots, screenshot/output paths, and exit behavior.

* **Documentation**
  * Added "Automation mode" docs with usage examples and bundled scenarios.

* **Tests**
  * New E2E automation test suite and example scenarios.

* **Chores**
  * CI: added dedicated Linux build/test and E2E automation jobs.
  * Added image dependency for PNG handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->