### PR TITLE
Beautify UI: improve spacing, padding, and visual hierarchy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-test-linux
     timeout-minutes: 20
+    permissions:
+      pull-requests: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,30 @@ jobs:
           name: automation-e2e-artifacts
           path: artifacts/e2e
           if-no-files-found: warn
+
+      - name: Post screenshot links to PR
+        if: always() && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          count=$(find artifacts/e2e -name '*.png' 2>/dev/null | wc -l)
+          if [ "$count" -eq 0 ]; then
+            echo "No screenshots found, skipping PR comment."
+            exit 0
+          fi
+
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          listing=$(find artifacts/e2e -name '*.png' -printf '%f\n' 2>/dev/null | sort)
+
+          body="## Automation Screenshots"$'\n\n'
+          body+="**${count} screenshot(s)** captured during this CI run."$'\n\n'
+          body+="| File | Size |"$'\n'
+          body+="| --- | --- |"$'\n'
+          for img in $(find artifacts/e2e -name '*.png' 2>/dev/null | sort); do
+            name=$(basename "$img")
+            size=$(du -h "$img" | cut -f1)
+            body+="| ${name} | ${size} |"$'\n'
+          done
+          body+=$'\n'"Download: [automation-e2e-artifacts](${run_url}) (see Artifacts section at bottom of the run page)"
+
+          gh pr comment "${{ github.event.pull_request.number }}" --body "$body"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,17 +89,16 @@ jobs:
           fi
 
           run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          listing=$(find artifacts/e2e -name '*.png' -printf '%f\n' 2>/dev/null | sort)
 
           body="## Automation Screenshots"$'\n\n'
           body+="**${count} screenshot(s)** captured during this CI run."$'\n\n'
           body+="| File | Size |"$'\n'
           body+="| --- | --- |"$'\n'
-          for img in $(find artifacts/e2e -name '*.png' 2>/dev/null | sort); do
+          while IFS= read -r -d '' img; do
             name=$(basename "$img")
             size=$(du -h "$img" | cut -f1)
             body+="| ${name} | ${size} |"$'\n'
-          done
+          done < <(find artifacts/e2e -name '*.png' -print0 2>/dev/null | sort -z)
           body+=$'\n'"Download: [automation-e2e-artifacts](${run_url}) (see Artifacts section at bottom of the run page)"
 
           gh pr comment "${{ github.event.pull_request.number }}" --body "$body"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1796,6 +1796,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iced_fonts"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "214cff7c8499e328774216690e58e315a1a5f8f6fdd1035aed6298e62ffc4c1d"
+dependencies = [
+ "iced_core",
+ "iced_fonts_macros",
+ "iced_widget",
+]
+
+[[package]]
+name = "iced_fonts_macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef5125e110cb19cd1910a28298661c98c5d9ab02eef43594968352940e8752e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "ttf-parser",
+]
+
+[[package]]
 name = "iced_futures"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6045,6 +6068,7 @@ dependencies = [
  "ego-tree",
  "futures",
  "iced",
+ "iced_fonts",
  "iced_highlighter",
  "image",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ scraper = "0.20"
 ego-tree = "0.6"
 vec1 = "1.12.1"
 image = { version = "0.25.9", default-features = false, features = ["png"] }
+iced_fonts = { version = "0.3", features = ["bootstrap"] }
 
 [dev-dependencies]
 tempfile = "3.12.0"

--- a/src/app/automation.rs
+++ b/src/app/automation.rs
@@ -478,6 +478,8 @@ impl Zagel {
                 }
                 Err(err) => self.fail_automation(&mut runtime, &err),
             }
+        } else if runtime.done {
+            Task::none()
         } else {
             self.fail_automation(
                 &mut runtime,

--- a/src/app/headers.rs
+++ b/src/app/headers.rs
@@ -1,7 +1,9 @@
-use iced::widget::{button, column, container, row, text_input};
+use iced::widget::{button, column, container, row, text, text_input, tooltip};
 use iced::{Alignment, Element, Length};
 
 use super::{HeaderRow, Message};
+use crate::icons;
+use crate::theme::{self, spacing, typo};
 
 pub fn editor(rows: &[HeaderRow]) -> Element<'_, Message> {
     let mut list = column![];
@@ -11,7 +13,7 @@ pub fn editor(rows: &[HeaderRow]) -> Element<'_, Message> {
         let name_input = container(
             text_input("Name", &row_data.name)
                 .on_input(move |val| Message::HeaderNameChanged(idx_name, val))
-                .padding(6)
+                .padding(spacing::XS)
                 .width(Length::Fill),
         )
         .width(Length::FillPortion(2))
@@ -21,20 +23,32 @@ pub fn editor(rows: &[HeaderRow]) -> Element<'_, Message> {
                 name_input,
                 text_input("Value", &row_data.value)
                     .on_input(move |val| Message::HeaderValueChanged(idx_value, val))
-                    .padding(6)
+                    .padding(spacing::XS)
                     .width(Length::FillPortion(5)),
-                button("x")
-                    .on_press(Message::HeaderRemoved(idx))
-                    .padding([5, 10]),
+                tooltip(
+                    button(icons::x_lg().size(typo::BODY))
+                        .on_press(Message::HeaderRemoved(idx))
+                        .padding([spacing::XXS, spacing::XS])
+                        .style(theme::ghost_button_style),
+                    "Remove header",
+                    tooltip::Position::Top,
+                ),
             ]
-            .spacing(6)
+            .spacing(spacing::XS)
             .align_y(Alignment::Center),
         );
     }
     list = list.push(
-        button("Add header")
-            .on_press(Message::HeaderAdded)
-            .padding([5, 10]),
+        button(
+            row![
+                icons::plus_lg().size(typo::BODY),
+                text("Add header").size(typo::BODY)
+            ]
+            .spacing(spacing::XXS)
+            .align_y(Alignment::Center),
+        )
+        .on_press(Message::HeaderAdded)
+        .padding([spacing::XXS, spacing::SM]),
     );
-    list.spacing(6).into()
+    list.spacing(spacing::XS).into()
 }

--- a/src/app/headers.rs
+++ b/src/app/headers.rs
@@ -1,5 +1,5 @@
 use iced::widget::{button, column, container, row, text_input};
-use iced::{Element, Length};
+use iced::{Alignment, Element, Length};
 
 use super::{HeaderRow, Message};
 
@@ -23,11 +23,18 @@ pub fn editor(rows: &[HeaderRow]) -> Element<'_, Message> {
                     .on_input(move |val| Message::HeaderValueChanged(idx_value, val))
                     .padding(6)
                     .width(Length::FillPortion(5)),
-                button("✕").on_press(Message::HeaderRemoved(idx)),
+                button("x")
+                    .on_press(Message::HeaderRemoved(idx))
+                    .padding([5, 10]),
             ]
-            .spacing(6),
+            .spacing(6)
+            .align_y(Alignment::Center),
         );
     }
-    list = list.push(button("Add header").on_press(Message::HeaderAdded));
+    list = list.push(
+        button("Add header")
+            .on_press(Message::HeaderAdded)
+            .padding([5, 10]),
+    );
     list.spacing(6).into()
 }

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -520,6 +520,7 @@ pub fn run(launch: LaunchOptions) -> iced::Result {
         view::view,
     )
     .title("Zagel - REST workbench")
+    .font(iced_fonts::BOOTSTRAP_FONT_BYTES)
     .subscription(Zagel::subscription)
     .theme(Zagel::theme)
     .run()

--- a/src/app/view/auth.rs
+++ b/src/app/view/auth.rs
@@ -13,20 +13,20 @@ pub fn auth_editor(auth: &AuthState) -> Element<'_, Message> {
     });
 
     let fields: Element<'_, Message> = match auth {
-        AuthState::None => text("No authentication").into(),
+        AuthState::None => text("No authentication").size(12).into(),
         AuthState::Bearer(bearer) => bearer_fields(bearer),
         AuthState::ApiKey(api_key) => api_key_fields(api_key),
         AuthState::Basic(basic) => basic_fields(basic),
         AuthState::OAuth2ClientCredentials(oauth) => oauth2_client_credentials_fields(oauth),
     };
 
-    column![kind_pick, fields].spacing(4).into()
+    column![kind_pick, fields].spacing(6).into()
 }
 
 fn bearer_fields(bearer: &BearerAuthState) -> Element<'_, Message> {
     text_input("Bearer token", &bearer.token)
         .on_input(|token| Message::AuthChanged(AuthState::Bearer(BearerAuthState { token })))
-        .padding(4)
+        .padding(6)
         .width(Length::Fill)
         .into()
 }
@@ -40,7 +40,7 @@ fn api_key_fields(api_key: &ApiKeyAuthState) -> Element<'_, Message> {
                     header_value: api_key.header_value.clone(),
                 }))
             })
-            .padding(4)
+            .padding(6)
             .width(Length::Fill),
         text_input("Header value", &api_key.header_value)
             .on_input(|header_value| {
@@ -49,10 +49,10 @@ fn api_key_fields(api_key: &ApiKeyAuthState) -> Element<'_, Message> {
                     header_value,
                 }))
             })
-            .padding(4)
+            .padding(6)
             .width(Length::Fill),
     ]
-    .spacing(4)
+    .spacing(6)
     .into()
 }
 
@@ -65,7 +65,7 @@ fn basic_fields(basic: &BasicAuthState) -> Element<'_, Message> {
                     password: basic.password.clone(),
                 }))
             })
-            .padding(4)
+            .padding(6)
             .width(Length::Fill),
         text_input("Password", &basic.password)
             .secure(true)
@@ -75,10 +75,10 @@ fn basic_fields(basic: &BasicAuthState) -> Element<'_, Message> {
                     password,
                 }))
             })
-            .padding(4)
+            .padding(6)
             .width(Length::Fill),
     ]
-    .spacing(4)
+    .spacing(6)
     .into()
 }
 
@@ -105,7 +105,7 @@ fn oauth2_client_credentials_fields(
                     oauth.clone().with_token_url(token_url),
                 ))
             })
-            .padding(4)
+            .padding(6)
             .width(Length::Fill),
         text_input("Client ID", &oauth.client_id)
             .on_input(|client_id| {
@@ -113,7 +113,7 @@ fn oauth2_client_credentials_fields(
                     oauth.clone().with_client_id(client_id),
                 ))
             })
-            .padding(4)
+            .padding(6)
             .width(Length::Fill),
         text_input("Client secret", &oauth.client_secret)
             .secure(true)
@@ -122,7 +122,7 @@ fn oauth2_client_credentials_fields(
                     oauth.clone().with_client_secret(client_secret),
                 ))
             })
-            .padding(4)
+            .padding(6)
             .width(Length::Fill),
         text_input("Scope (optional)", &oauth.scope)
             .on_input(|scope| {
@@ -130,10 +130,10 @@ fn oauth2_client_credentials_fields(
                     oauth.clone().with_scope(scope),
                 ))
             })
-            .padding(4)
+            .padding(6)
             .width(Length::Fill),
         method_pick,
     ]
-    .spacing(4)
+    .spacing(6)
     .into()
 }

--- a/src/app/view/auth.rs
+++ b/src/app/view/auth.rs
@@ -6,6 +6,7 @@ use crate::app::options::{
     ApiKeyAuthState, AuthKind, AuthState, BasicAuthState, BearerAuthState, ClientSecretMethod,
     OAuth2ClientCredentialsAuthState,
 };
+use crate::theme::{spacing, typo};
 
 pub fn auth_editor(auth: &AuthState) -> Element<'_, Message> {
     let kind_pick = pick_list(AuthKind::ALL.to_vec(), Some(auth.kind()), |kind| {
@@ -13,20 +14,20 @@ pub fn auth_editor(auth: &AuthState) -> Element<'_, Message> {
     });
 
     let fields: Element<'_, Message> = match auth {
-        AuthState::None => text("No authentication").size(12).into(),
+        AuthState::None => text("No authentication").size(typo::CAPTION).into(),
         AuthState::Bearer(bearer) => bearer_fields(bearer),
         AuthState::ApiKey(api_key) => api_key_fields(api_key),
         AuthState::Basic(basic) => basic_fields(basic),
         AuthState::OAuth2ClientCredentials(oauth) => oauth2_client_credentials_fields(oauth),
     };
 
-    column![kind_pick, fields].spacing(6).into()
+    column![kind_pick, fields].spacing(spacing::SM).into()
 }
 
 fn bearer_fields(bearer: &BearerAuthState) -> Element<'_, Message> {
     text_input("Bearer token", &bearer.token)
         .on_input(|token| Message::AuthChanged(AuthState::Bearer(BearerAuthState { token })))
-        .padding(6)
+        .padding(spacing::XS)
         .width(Length::Fill)
         .into()
 }
@@ -40,7 +41,7 @@ fn api_key_fields(api_key: &ApiKeyAuthState) -> Element<'_, Message> {
                     header_value: api_key.header_value.clone(),
                 }))
             })
-            .padding(6)
+            .padding(spacing::XS)
             .width(Length::Fill),
         text_input("Header value", &api_key.header_value)
             .on_input(|header_value| {
@@ -49,10 +50,10 @@ fn api_key_fields(api_key: &ApiKeyAuthState) -> Element<'_, Message> {
                     header_value,
                 }))
             })
-            .padding(6)
+            .padding(spacing::XS)
             .width(Length::Fill),
     ]
-    .spacing(6)
+    .spacing(spacing::XS)
     .into()
 }
 
@@ -65,7 +66,7 @@ fn basic_fields(basic: &BasicAuthState) -> Element<'_, Message> {
                     password: basic.password.clone(),
                 }))
             })
-            .padding(6)
+            .padding(spacing::XS)
             .width(Length::Fill),
         text_input("Password", &basic.password)
             .secure(true)
@@ -75,10 +76,10 @@ fn basic_fields(basic: &BasicAuthState) -> Element<'_, Message> {
                     password,
                 }))
             })
-            .padding(6)
+            .padding(spacing::XS)
             .width(Length::Fill),
     ]
-    .spacing(6)
+    .spacing(spacing::XS)
     .into()
 }
 
@@ -105,7 +106,7 @@ fn oauth2_client_credentials_fields(
                     oauth.clone().with_token_url(token_url),
                 ))
             })
-            .padding(6)
+            .padding(spacing::XS)
             .width(Length::Fill),
         text_input("Client ID", &oauth.client_id)
             .on_input(|client_id| {
@@ -113,7 +114,7 @@ fn oauth2_client_credentials_fields(
                     oauth.clone().with_client_id(client_id),
                 ))
             })
-            .padding(6)
+            .padding(spacing::XS)
             .width(Length::Fill),
         text_input("Client secret", &oauth.client_secret)
             .secure(true)
@@ -122,7 +123,7 @@ fn oauth2_client_credentials_fields(
                     oauth.clone().with_client_secret(client_secret),
                 ))
             })
-            .padding(6)
+            .padding(spacing::XS)
             .width(Length::Fill),
         text_input("Scope (optional)", &oauth.scope)
             .on_input(|scope| {
@@ -130,10 +131,10 @@ fn oauth2_client_credentials_fields(
                     oauth.clone().with_scope(scope),
                 ))
             })
-            .padding(6)
+            .padding(spacing::XS)
             .width(Length::Fill),
         method_pick,
     ]
-    .spacing(6)
+    .spacing(spacing::XS)
     .into()
 }

--- a/src/app/view/mod.rs
+++ b/src/app/view/mod.rs
@@ -5,7 +5,7 @@ mod workspace;
 
 use iced::widget::pane_grid::{self, PaneGrid};
 use iced::widget::{column, container, row, space, text};
-use iced::{Element, Length};
+use iced::{Alignment, Element, Length};
 
 use super::{Message, Zagel};
 use sidebar::{SidebarContext, sidebar};
@@ -15,7 +15,7 @@ pub use response::{ResponseData, ResponseDisplay, ResponseTab};
 pub use sidebar::IconSet;
 pub use workspace::{BuilderPane, WorkspacePane};
 
-use crate::theme;
+use crate::theme::{self, spacing, typo};
 
 #[derive(Debug, Clone, Copy)]
 pub enum PaneContent {
@@ -23,18 +23,23 @@ pub enum PaneContent {
     Workspace,
 }
 
-pub fn section<'a, Message: 'a>(
+/// Section card with an icon next to the title.
+pub fn section<'a, M: 'a>(
     title: &'a str,
-    content: Element<'a, Message>,
-) -> Element<'a, Message> {
+    icon: impl Into<Element<'a, M>>,
+    content: Element<'a, M>,
+) -> Element<'a, M> {
+    let title_row = row![
+        icon.into(),
+        text(title).size(typo::BODY),
+    ]
+    .spacing(spacing::XXS)
+    .align_y(Alignment::Center);
+
     container(
-        column![
-            text(title).size(13).color(iced::Color::from_rgba(0.6, 0.65, 0.75, 0.85)),
-            content,
-        ]
-        .spacing(8),
+        column![title_row, content].spacing(spacing::SM),
     )
-    .padding(12)
+    .padding(spacing::MD)
     .width(Length::Fill)
     .style(theme::section_container_style)
     .into()
@@ -60,7 +65,7 @@ pub fn view(app: &Zagel) -> Element<'_, Message> {
     })
     .width(Length::Fill)
     .height(Length::Fill)
-    .spacing(2.0)
+    .spacing(spacing::XXXS)
     .on_resize(6, Message::PaneResized);
 
     column![
@@ -78,14 +83,14 @@ fn status_bar(app: &Zagel) -> Element<'_, Message> {
     };
 
     let content = row![
-        text(hint).size(11),
+        text(hint).size(typo::CAPTION),
         space().width(Length::Fill),
-        text(format!("Status: {}", app.status_line)).size(11),
+        text(format!("Status: {}", app.status_line)).size(typo::CAPTION),
     ]
-    .spacing(12);
+    .spacing(spacing::MD);
 
     container(content)
-        .padding([5, 14])
+        .padding([spacing::XXS, spacing::LG])
         .width(Length::Fill)
         .style(theme::status_bar_style)
         .into()

--- a/src/app/view/mod.rs
+++ b/src/app/view/mod.rs
@@ -4,7 +4,7 @@ mod sidebar;
 mod workspace;
 
 use iced::widget::pane_grid::{self, PaneGrid};
-use iced::widget::{column, container, row, rule, space, text};
+use iced::widget::{column, container, row, space, text};
 use iced::{Element, Length};
 
 use super::{Message, Zagel};
@@ -14,6 +14,8 @@ use workspace::workspace;
 pub use response::{ResponseData, ResponseDisplay, ResponseTab};
 pub use sidebar::IconSet;
 pub use workspace::{BuilderPane, WorkspacePane};
+
+use crate::theme;
 
 #[derive(Debug, Clone, Copy)]
 pub enum PaneContent {
@@ -25,11 +27,17 @@ pub fn section<'a, Message: 'a>(
     title: &'a str,
     content: Element<'a, Message>,
 ) -> Element<'a, Message> {
-    container(column![text(title).size(15), rule::horizontal(1), content].spacing(6))
-        .padding(12)
-        .width(Length::Fill)
-        .style(container::bordered_box)
-        .into()
+    container(
+        column![
+            text(title).size(13).color(iced::Color::from_rgba(0.6, 0.65, 0.75, 0.85)),
+            content,
+        ]
+        .spacing(8),
+    )
+    .padding(12)
+    .width(Length::Fill)
+    .style(theme::section_container_style)
+    .into()
 }
 
 pub fn view(app: &Zagel) -> Element<'_, Message> {
@@ -52,12 +60,11 @@ pub fn view(app: &Zagel) -> Element<'_, Message> {
     })
     .width(Length::Fill)
     .height(Length::Fill)
-    .spacing(8.0)
+    .spacing(2.0)
     .on_resize(6, Message::PaneResized);
 
     column![
         container(grid).height(Length::Fill),
-        rule::horizontal(1),
         status_bar(app_ref)
     ]
     .into()
@@ -71,11 +78,15 @@ fn status_bar(app: &Zagel) -> Element<'_, Message> {
     };
 
     let content = row![
-        text(hint).size(12),
+        text(hint).size(11),
         space().width(Length::Fill),
-        text(format!("Status: {}", app.status_line)).size(12),
+        text(format!("Status: {}", app.status_line)).size(11),
     ]
-    .spacing(8);
+    .spacing(12);
 
-    container(content).padding([6, 12]).into()
+    container(content)
+        .padding([5, 14])
+        .width(Length::Fill)
+        .style(theme::status_bar_style)
+        .into()
 }

--- a/src/app/view/response.rs
+++ b/src/app/view/response.rs
@@ -169,22 +169,24 @@ impl std::fmt::Display for ResponseTab {
 
 /// Creates a toggle widget for switching between Body and Headers tabs in the response view.
 pub fn response_tab_toggle(current: ResponseTab) -> Element<'static, Message> {
-    let body = button(text("Body"))
+    let body = button(text("Body").size(13))
         .style(if current == ResponseTab::Body {
             button::primary
         } else {
             button::secondary
         })
+        .padding([5, 10])
         .on_press(Message::ResponseTabChanged(ResponseTab::Body));
-    let headers = button(text("Headers"))
+    let headers = button(text("Headers").size(13))
         .style(if current == ResponseTab::Headers {
             button::primary
         } else {
             button::secondary
         })
+        .padding([5, 10])
         .on_press(Message::ResponseTabChanged(ResponseTab::Headers));
 
-    row![body, headers].spacing(6).into()
+    row![body, headers].spacing(4).into()
 }
 
 /// Creates a pick list widget for switching between Raw and Pretty response display modes.
@@ -210,7 +212,7 @@ pub fn response_panel<'a>(
     highlight_theme: HighlightTheme,
 ) -> Element<'a, Message> {
     response.map_or_else(
-        || text("No response yet").into(),
+        || text("No response yet").size(13).into(),
         |response| {
             let resp = &response.preview;
             let body = &response.body;
@@ -250,15 +252,15 @@ pub fn response_panel<'a>(
                         (ResponseDisplay::Raw, _) => "raw",
                     }
                 ))
-                .size(14),
+                .size(12),
                 body_editor,
             ]
             .spacing(6)
             .into();
 
             let headers_section: Element<'_, Message> = column![
-                text("Headers").size(14),
-                scrollable(headers_view.spacing(4)).height(Length::Fill),
+                text("Headers").size(12),
+                scrollable(headers_view.spacing(3)).height(Length::Fill),
             ]
             .spacing(6)
             .into();
@@ -269,11 +271,11 @@ pub fn response_panel<'a>(
             };
 
             column![
-                text(header).size(16),
+                text(header).size(14),
                 rule::horizontal(1),
                 container(tab_view).height(Length::Fill),
             ]
-            .spacing(6)
+            .spacing(8)
             .height(Length::Fill)
             .into()
         },
@@ -582,7 +584,7 @@ fn html_parse_mode(raw: &str) -> HtmlParseMode {
 
 #[cfg(test)]
 mod tests {
-    use super::{HtmlParseMode, html_parse_mode, pretty_html};
+    use super::{html_parse_mode, pretty_html, HtmlParseMode};
 
     #[test]
     fn html_parse_mode_detects_document_markers() {

--- a/src/app/view/response.rs
+++ b/src/app/view/response.rs
@@ -3,12 +3,13 @@ use iced::widget::text::Wrapping;
 use iced::widget::{
     button, column, container, pick_list, row, rule, scrollable, text, text_editor,
 };
-use iced::{Element, Length};
+use iced::{Alignment, Element, Length};
 use iced_highlighter::Theme as HighlightTheme;
 use scraper::{Html, Node};
 
 use super::super::Message;
 use crate::model::ResponsePreview;
+use crate::theme::{self, spacing, typo};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SyntaxKind {
@@ -169,24 +170,24 @@ impl std::fmt::Display for ResponseTab {
 
 /// Creates a toggle widget for switching between Body and Headers tabs in the response view.
 pub fn response_tab_toggle(current: ResponseTab) -> Element<'static, Message> {
-    let body = button(text("Body").size(13))
+    let body = button(text("Body").size(typo::BODY))
         .style(if current == ResponseTab::Body {
             button::primary
         } else {
             button::secondary
         })
-        .padding([5, 10])
+        .padding([spacing::XXS, spacing::SM])
         .on_press(Message::ResponseTabChanged(ResponseTab::Body));
-    let headers = button(text("Headers").size(13))
+    let headers = button(text("Headers").size(typo::BODY))
         .style(if current == ResponseTab::Headers {
             button::primary
         } else {
             button::secondary
         })
-        .padding([5, 10])
+        .padding([spacing::XXS, spacing::SM])
         .on_press(Message::ResponseTabChanged(ResponseTab::Headers));
 
-    row![body, headers].spacing(4).into()
+    row![body, headers].spacing(spacing::XXS).into()
 }
 
 /// Creates a pick list widget for switching between Raw and Pretty response display modes.
@@ -204,34 +205,64 @@ pub fn response_view_toggle(current: ResponseDisplay) -> Element<'static, Messag
 /// Displays the HTTP response status, duration, and either the body or headers
 /// based on the selected tab. Supports both raw and pretty-printed views for
 /// JSON and HTML content.
+#[allow(clippy::too_many_lines)]
 pub fn response_panel<'a>(
-    response: Option<&ResponseData>,
+    response: Option<&'a ResponseData>,
     content: &'a text_editor::Content,
     display: ResponseDisplay,
     tab: ResponseTab,
     highlight_theme: HighlightTheme,
 ) -> Element<'a, Message> {
     response.map_or_else(
-        || text("No response yet").size(13).into(),
+        || text("No response yet").size(typo::BODY).into(),
         |response| {
             let resp = &response.preview;
             let body = &response.body;
-            let header = match (resp.status, resp.duration) {
+
+            // Status line with colored status code
+            let header: Element<'_, Message> = match (resp.status, resp.duration) {
                 (Some(status), Some(duration)) => {
-                    format!("HTTP {status} in {} ms", duration.as_millis())
+                    let color = theme::status_color(status);
+                    row![
+                        text("HTTP").size(typo::HEADING),
+                        text(status.to_string()).size(typo::HEADING).color(color),
+                        text(format!("in {} ms", duration.as_millis())).size(typo::BODY),
+                    ]
+                    .spacing(spacing::XXS)
+                    .align_y(Alignment::Center)
+                    .into()
                 }
-                (Some(status), None) => format!("HTTP {status}"),
-                _ => "No response".to_string(),
+                (Some(status), None) => {
+                    let color = theme::status_color(status);
+                    row![
+                        text("HTTP").size(typo::HEADING),
+                        text(status.to_string()).size(typo::HEADING).color(color),
+                    ]
+                    .spacing(spacing::XXS)
+                    .align_y(Alignment::Center)
+                    .into()
+                }
+                _ => text("No response").size(typo::HEADING).into(),
             };
 
-            let mut headers_view = column![];
-            if resp.headers.is_empty() {
-                headers_view = headers_view.push(text("No headers").size(12));
+            // Headers as a key-value table
+            let headers_view: Element<'_, Message> = if resp.headers.is_empty() {
+                text("No headers").size(typo::CAPTION).into()
             } else {
+                let mut header_rows = column![].spacing(spacing::XXXS);
                 for (name, value) in &resp.headers {
-                    headers_view = headers_view.push(text(format!("{name}: {value}")).size(12));
+                    header_rows = header_rows.push(
+                        row![
+                            container(text(name).size(typo::CAPTION)).width(Length::FillPortion(2)),
+                            container(text(value).size(typo::CAPTION))
+                                .width(Length::FillPortion(5)),
+                        ]
+                        .spacing(spacing::SM)
+                        .align_y(Alignment::Start),
+                    );
                 }
-            }
+                scrollable(header_rows).height(Length::Fill).into()
+            };
 
             let pretty_kind = body.pretty_kind();
             let syntax = body.syntax();
@@ -252,18 +283,16 @@ pub fn response_panel<'a>(
                         (ResponseDisplay::Raw, _) => "raw",
                     }
                 ))
-                .size(12),
+                .size(typo::CAPTION),
                 body_editor,
             ]
-            .spacing(6)
+            .spacing(spacing::XS)
             .into();
 
-            let headers_section: Element<'_, Message> = column![
-                text("Headers").size(12),
-                scrollable(headers_view.spacing(3)).height(Length::Fill),
-            ]
-            .spacing(6)
-            .into();
+            let headers_section: Element<'_, Message> =
+                column![text("Headers").size(typo::CAPTION), headers_view,]
+                    .spacing(spacing::XS)
+                    .into();
 
             let tab_view: Element<'_, Message> = match tab {
                 ResponseTab::Body => body_section,
@@ -271,11 +300,11 @@ pub fn response_panel<'a>(
             };
 
             column![
-                text(header).size(14),
+                header,
                 rule::horizontal(1),
                 container(tab_view).height(Length::Fill),
             ]
-            .spacing(8)
+            .spacing(spacing::SM)
             .height(Length::Fill)
             .into()
         },

--- a/src/app/view/sidebar.rs
+++ b/src/app/view/sidebar.rs
@@ -5,12 +5,13 @@ use iced::widget::{Space, button, column, container, row, scrollable, text, text
 use iced::{Alignment, Element, Length};
 
 use crate::pathing::{GlobalEnvRoot, ProjectRoot};
+use crate::theme;
 
 use super::super::{EditState, EditTarget, Message};
 use super::section;
 use crate::model::{HttpFile, RequestDraft, RequestId};
 
-const INDENT: i16 = 10;
+const INDENT: i16 = 14;
 
 #[derive(Debug, Clone, Copy)]
 pub enum IconSet {
@@ -114,19 +115,23 @@ pub fn sidebar(ctx: SidebarContext<'_>) -> Element<'_, Message> {
 
     let project_input = text_input("C:/path/to/project", ctx.project_path_input)
         .on_input(Message::ProjectPathInputChanged)
-        .padding(4)
+        .padding(6)
         .width(Length::FillPortion(4));
-    let add_project = button("Add project").on_press(Message::AddProject);
+    let add_project = button("Add project")
+        .on_press(Message::AddProject)
+        .padding([5, 10]);
 
     let mut project_roots = column![row![project_input, add_project].spacing(6)].spacing(6);
     if ctx.project_roots.is_empty() {
-        project_roots = project_roots.push(text("No projects configured").size(13));
+        project_roots = project_roots.push(text("No projects configured").size(12));
     } else {
         for root in ctx.project_roots {
             project_roots = project_roots.push(
                 row![
-                    text(root.as_path().display().to_string()).size(13),
-                    button("Remove").on_press(Message::RemoveProject(root.clone())),
+                    text(root.as_path().display().to_string()).size(12),
+                    button("Remove")
+                        .on_press(Message::RemoveProject(root.clone()))
+                        .padding([3, 8]),
                 ]
                 .align_y(Alignment::Center)
                 .spacing(6),
@@ -136,19 +141,23 @@ pub fn sidebar(ctx: SidebarContext<'_>) -> Element<'_, Message> {
 
     let global_env_input = text_input("C:/path/to/global/envs", ctx.global_env_path_input)
         .on_input(Message::GlobalEnvPathInputChanged)
-        .padding(4)
+        .padding(6)
         .width(Length::FillPortion(4));
-    let add_global = button("Add global envs").on_press(Message::AddGlobalEnvRoot);
+    let add_global = button("Add global envs")
+        .on_press(Message::AddGlobalEnvRoot)
+        .padding([5, 10]);
 
     let mut global_env_roots = column![row![global_env_input, add_global].spacing(6)].spacing(6);
     if ctx.global_env_roots.is_empty() {
-        global_env_roots = global_env_roots.push(text("No global env folders").size(13));
+        global_env_roots = global_env_roots.push(text("No global env folders").size(12));
     } else {
         for root in ctx.global_env_roots {
             global_env_roots = global_env_roots.push(
                 row![
-                    text(root.as_path().display().to_string()).size(13),
-                    button("Remove").on_press(Message::RemoveGlobalEnvRoot(root.clone())),
+                    text(root.as_path().display().to_string()).size(12),
+                    button("Remove")
+                        .on_press(Message::RemoveGlobalEnvRoot(root.clone()))
+                        .padding([3, 8]),
                 ]
                 .align_y(Alignment::Center)
                 .spacing(6),
@@ -157,23 +166,35 @@ pub fn sidebar(ctx: SidebarContext<'_>) -> Element<'_, Message> {
     }
 
     let mut header = row![
-        text("Requests").size(20),
-        button("Add").on_press(Message::AddRequest)
+        text("Requests").size(16),
+        button("Add")
+            .on_press(Message::AddRequest)
+            .padding([4, 10])
     ]
     .align_y(Alignment::Center)
     .spacing(6);
     if editing {
         let selection_empty = edit_selection.is_none_or(HashSet::is_empty);
         let delete_button = if selection_empty {
-            button("Delete")
+            button("Delete").padding([4, 10])
         } else {
-            button("Delete").on_press(Message::DeleteSelected)
+            button("Delete")
+                .on_press(Message::DeleteSelected)
+                .padding([4, 10])
         };
         header = header
             .push(delete_button)
-            .push(button("Done").on_press(Message::ToggleEditMode));
+            .push(
+                button("Done")
+                    .on_press(Message::ToggleEditMode)
+                    .padding([4, 10]),
+            );
     } else {
-        header = header.push(button("Edit").on_press(Message::ToggleEditMode));
+        header = header.push(
+            button("Edit")
+                .on_press(Message::ToggleEditMode)
+                .padding([4, 10]),
+        );
     }
 
     let mut tree = TreeNode::default();
@@ -234,7 +255,7 @@ pub fn sidebar(ctx: SidebarContext<'_>) -> Element<'_, Message> {
         edit_selection,
         icons,
     };
-    let list = render_tree(column![], &tree, "", 0, &render_ctx).spacing(4);
+    let list = render_tree(column![], &tree, "", 0, &render_ctx).spacing(3);
     let project_section = section("Projects", project_roots.into());
     let global_env_section = section("Global Environments", global_env_roots.into());
     let collections_section = section("Collections", list.into());
@@ -252,9 +273,10 @@ pub fn sidebar(ctx: SidebarContext<'_>) -> Element<'_, Message> {
     .height(Length::Fill);
 
     container(list)
-        .padding(8)
+        .padding(10)
         .width(Length::Fill)
         .height(Length::Fill)
+        .style(theme::sidebar_container_style)
         .into()
 }
 
@@ -371,7 +393,7 @@ fn collection_row<'a>(
     };
     let toggle = button(text(toggle_label))
         .style(button::secondary)
-        .padding([2, 4])
+        .padding([3, 6])
         .on_press(Message::ToggleCollection(full_path.to_string()));
 
     let mut row_widgets = row![Space::new().width(Length::Fixed(indent_px(depth))), toggle];
@@ -389,17 +411,17 @@ fn collection_row<'a>(
         row_widgets = row_widgets
             .push(
                 button(text(label))
-                    .padding([2, 4])
+                    .padding([3, 6])
                     .on_press(Message::ToggleEditSelection(target)),
             )
             .push(
                 button(text(ctx.icons.move_up))
-                    .padding([2, 4])
+                    .padding([3, 6])
                     .on_press(Message::MoveCollectionUp(collection_path.clone())),
             )
             .push(
                 button(text(ctx.icons.move_down))
-                    .padding([2, 4])
+                    .padding([3, 6])
                     .on_press(Message::MoveCollectionDown(collection_path)),
             );
     }
@@ -415,20 +437,23 @@ fn collection_row<'a>(
         };
 
         row_widgets.push(
-            button(text(child.name.clone()).size(14))
+            button(text(child.name.clone()).size(13))
                 .style(if is_selected {
                     button::primary
                 } else {
                     button::secondary
                 })
+                .padding([4, 8])
                 .width(Length::Fill)
                 .on_press(Message::Select(select_id)),
         )
     } else {
-        row_widgets.push(text(child.name.clone()).size(14))
+        row_widgets.push(text(child.name.clone()).size(13))
     };
 
-    row_widgets.spacing(4)
+    row_widgets
+        .spacing(4)
+        .align_y(Alignment::Center)
 }
 
 fn request_row<'a>(
@@ -458,30 +483,33 @@ fn request_row<'a>(
         row_widgets = row_widgets
             .push(
                 button(text(select_label))
-                    .padding([2, 4])
+                    .padding([3, 6])
                     .on_press(Message::ToggleEditSelection(target)),
             )
             .push(
                 button(text(ctx.icons.move_up))
-                    .padding([2, 4])
+                    .padding([3, 6])
                     .on_press(Message::MoveRequestUp(item.id.clone())),
             )
             .push(
                 button(text(ctx.icons.move_down))
-                    .padding([2, 4])
+                    .padding([3, 6])
                     .on_press(Message::MoveRequestDown(item.id.clone())),
             );
     }
     row_widgets = row_widgets.push(
-        button(text(label))
+        button(text(label).size(13))
             .style(if is_selected {
                 button::primary
             } else {
                 button::secondary
             })
+            .padding([4, 8])
             .width(Length::Fill)
             .on_press(Message::Select(item.id.clone())),
     );
 
-    row_widgets.spacing(4)
+    row_widgets
+        .spacing(4)
+        .align_y(Alignment::Center)
 }

--- a/src/app/view/sidebar.rs
+++ b/src/app/view/sidebar.rs
@@ -86,7 +86,7 @@ pub fn sidebar(ctx: SidebarContext<'_>) -> Element<'_, Message> {
         .width(Length::FillPortion(4));
     let add_project = tooltip(
         button(
-            row![icons::plus_circle().size(typo::BODY), text("Add").size(typo::BODY)]
+            row![add_action_icon(ctx.icon_set), text("Add").size(typo::BODY)]
                 .spacing(spacing::XXS)
                 .align_y(Alignment::Center),
         )
@@ -106,7 +106,7 @@ pub fn sidebar(ctx: SidebarContext<'_>) -> Element<'_, Message> {
                 row![
                     text(root.as_path().display().to_string()).size(typo::CAPTION),
                     tooltip(
-                        button(icons::dash_circle().size(typo::BODY))
+                        button(remove_action_icon(ctx.icon_set))
                             .on_press(Message::RemoveProject(root.clone()))
                             .padding([spacing::XXXS, spacing::XXS])
                             .style(theme::ghost_button_style),
@@ -126,7 +126,7 @@ pub fn sidebar(ctx: SidebarContext<'_>) -> Element<'_, Message> {
         .width(Length::FillPortion(4));
     let add_global = tooltip(
         button(
-            row![icons::plus_circle().size(typo::BODY), text("Add").size(typo::BODY)]
+            row![add_action_icon(ctx.icon_set), text("Add").size(typo::BODY)]
                 .spacing(spacing::XXS)
                 .align_y(Alignment::Center),
         )
@@ -146,7 +146,7 @@ pub fn sidebar(ctx: SidebarContext<'_>) -> Element<'_, Message> {
                 row![
                     text(root.as_path().display().to_string()).size(typo::CAPTION),
                     tooltip(
-                        button(icons::dash_circle().size(typo::BODY))
+                        button(remove_action_icon(ctx.icon_set))
                             .on_press(Message::RemoveGlobalEnvRoot(root.clone()))
                             .padding([spacing::XXXS, spacing::XXS])
                             .style(theme::ghost_button_style),
@@ -164,7 +164,7 @@ pub fn sidebar(ctx: SidebarContext<'_>) -> Element<'_, Message> {
         text("Requests").size(typo::TITLE),
         tooltip(
             button(
-                row![icons::plus_circle().size(typo::BODY), text("Add").size(typo::BODY)]
+                row![add_action_icon(ctx.icon_set), text("Add").size(typo::BODY)]
                     .spacing(spacing::XXS)
                     .align_y(Alignment::Center),
             )
@@ -181,7 +181,7 @@ pub fn sidebar(ctx: SidebarContext<'_>) -> Element<'_, Message> {
         let selection_empty = edit_selection.is_none_or(HashSet::is_empty);
         let delete_button = if selection_empty {
             button(
-                row![icons::trash().size(typo::BODY), text("Delete").size(typo::BODY)]
+                row![delete_action_icon(ctx.icon_set), text("Delete").size(typo::BODY)]
                     .spacing(spacing::XXS)
                     .align_y(Alignment::Center),
             )
@@ -189,7 +189,7 @@ pub fn sidebar(ctx: SidebarContext<'_>) -> Element<'_, Message> {
             .style(theme::destructive_button_style)
         } else {
             button(
-                row![icons::trash().size(typo::BODY), text("Delete").size(typo::BODY)]
+                row![delete_action_icon(ctx.icon_set), text("Delete").size(typo::BODY)]
                     .spacing(spacing::XXS)
                     .align_y(Alignment::Center),
             )
@@ -201,7 +201,7 @@ pub fn sidebar(ctx: SidebarContext<'_>) -> Element<'_, Message> {
             .push(delete_button)
             .push(
                 button(
-                    row![icons::check_lg().size(typo::BODY), text("Done").size(typo::BODY)]
+                    row![done_action_icon(ctx.icon_set), text("Done").size(typo::BODY)]
                         .spacing(spacing::XXS)
                         .align_y(Alignment::Center),
                 )
@@ -212,7 +212,7 @@ pub fn sidebar(ctx: SidebarContext<'_>) -> Element<'_, Message> {
         header = header.push(
             tooltip(
                 button(
-                    row![icons::pencil().size(typo::BODY), text("Edit").size(typo::BODY)]
+                    row![edit_action_icon(ctx.icon_set), text("Edit").size(typo::BODY)]
                         .spacing(spacing::XXS)
                         .align_y(Alignment::Center),
                 )
@@ -450,6 +450,41 @@ fn checkbox_icon(checked: bool, icon_set: IconSet) -> Element<'static, Message> 
             let label = if checked { "[x]" } else { "[ ]" };
             text(label).size(typo::CAPTION).into()
         }
+    }
+}
+
+fn add_action_icon(icon_set: IconSet) -> Element<'static, Message> {
+    match icon_set {
+        IconSet::Bootstrap => Element::from(icons::plus_circle().size(typo::BODY)),
+        IconSet::Ascii => Element::from(text("+").size(typo::BODY)),
+    }
+}
+
+fn remove_action_icon(icon_set: IconSet) -> Element<'static, Message> {
+    match icon_set {
+        IconSet::Bootstrap => Element::from(icons::dash_circle().size(typo::BODY)),
+        IconSet::Ascii => Element::from(text("-").size(typo::BODY)),
+    }
+}
+
+fn delete_action_icon(icon_set: IconSet) -> Element<'static, Message> {
+    match icon_set {
+        IconSet::Bootstrap => Element::from(icons::trash().size(typo::BODY)),
+        IconSet::Ascii => Element::from(text("x").size(typo::BODY)),
+    }
+}
+
+fn done_action_icon(icon_set: IconSet) -> Element<'static, Message> {
+    match icon_set {
+        IconSet::Bootstrap => Element::from(icons::check_lg().size(typo::BODY)),
+        IconSet::Ascii => Element::from(text("v").size(typo::BODY)),
+    }
+}
+
+fn edit_action_icon(icon_set: IconSet) -> Element<'static, Message> {
+    match icon_set {
+        IconSet::Bootstrap => Element::from(icons::pencil().size(typo::BODY)),
+        IconSet::Ascii => Element::from(text("~").size(typo::BODY)),
     }
 }
 

--- a/src/app/view/workspace.rs
+++ b/src/app/view/workspace.rs
@@ -2,9 +2,9 @@ use iced::widget::pane_grid::{self, PaneGrid};
 use iced::widget::{
     button, column, container, pick_list, row, scrollable, stack, text, text_editor, text_input,
 };
-use iced::{Alignment, Element, Length, Theme, alignment};
+use iced::{alignment, Alignment, Element, Length, Theme};
 
-use super::super::{Message, Zagel, headers};
+use super::super::{headers, Message, Zagel};
 use super::auth::auth_editor;
 use super::response::{response_panel, response_tab_toggle, response_view_toggle};
 use super::section;
@@ -28,7 +28,7 @@ const ENV_PICK_MAX_WIDTH: f32 = 180.0;
 const MODE_PICK_MAX_WIDTH: f32 = 150.0;
 const METHOD_PICK_MAX_WIDTH: f32 = 120.0;
 const ACTION_WIDTH: f32 = 84.0;
-const LABEL_WIDTH: f32 = 80.0;
+const LABEL_WIDTH: f32 = 72.0;
 
 pub fn workspace(app: &Zagel) -> Element<'_, Message> {
     let workspace_grid = PaneGrid::new(&app.workspace_panes, move |_, pane, _| match pane {
@@ -37,20 +37,14 @@ pub fn workspace(app: &Zagel) -> Element<'_, Message> {
     })
     .width(Length::Fill)
     .height(Length::Fill)
-    .spacing(8.0)
+    .spacing(4.0)
     .on_resize(6, Message::WorkspacePaneResized);
 
-    let header = text("Request Builder").size(20);
-
-    container(
-        column![header, workspace_grid]
-            .spacing(8)
-            .height(Length::Fill),
-    )
-    .padding(8)
-    .width(Length::Fill)
-    .height(Length::Fill)
-    .into()
+    container(workspace_grid)
+        .padding(6)
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .into()
 }
 
 fn builder(app: &Zagel) -> Element<'_, Message> {
@@ -66,6 +60,7 @@ fn builder(app: &Zagel) -> Element<'_, Message> {
     builder_grid.into()
 }
 
+#[allow(clippy::too_many_lines)]
 fn builder_form(app: &Zagel) -> Element<'_, Message> {
     let env_pick = container(
         pick_list(
@@ -99,26 +94,26 @@ fn builder_form(app: &Zagel) -> Element<'_, Message> {
 
     let title_input = text_input("Title", &app.draft.title)
         .on_input(Message::TitleChanged)
-        .padding(4)
+        .padding(6)
         .width(Length::FillPortion(5));
 
     let save_path_row: Element<'_, Message> = match app.workspace.selection() {
         Some(RequestId::HttpFile { path, .. }) => row![
-            container(text("Saving to").size(14)).width(Length::Fixed(LABEL_WIDTH)),
-            container(text(path.display().to_string()).size(14)).width(Length::Fill)
+            container(text("Saving to").size(12)).width(Length::Fixed(LABEL_WIDTH)),
+            container(text(path.display().to_string()).size(12)).width(Length::Fill)
         ]
         .align_y(Alignment::Center)
-        .spacing(6)
+        .spacing(8)
         .into(),
         _ => row![
-            container(text("Save as").size(14)).width(Length::Fixed(LABEL_WIDTH)),
+            container(text("Save as").size(12)).width(Length::Fixed(LABEL_WIDTH)),
             text_input("path/to/request.http", &app.save_path)
                 .on_input(Message::SavePathChanged)
-                .padding(4)
+                .padding(6)
                 .width(Length::Fill),
         ]
         .align_y(Alignment::Center)
-        .spacing(6)
+        .spacing(8)
         .into(),
     };
 
@@ -140,26 +135,28 @@ fn builder_form(app: &Zagel) -> Element<'_, Message> {
             title_input,
             button("Save")
                 .on_press(Message::Save)
+                .padding([6, 12])
                 .width(Length::Fixed(ACTION_WIDTH)),
         ]
         .align_y(Alignment::Center)
-        .spacing(6),
+        .spacing(8),
         save_path_row,
         row![env_pick, mode_pick]
             .align_y(Alignment::Center)
-            .spacing(6),
+            .spacing(8),
     ]
-    .spacing(6);
+    .spacing(8);
 
     let request_section = row![
         method_pick,
         url_input,
         button("Send")
             .on_press(Message::Send)
+            .padding([6, 12])
             .width(Length::Fixed(ACTION_WIDTH)),
     ]
     .align_y(Alignment::Center)
-    .spacing(6);
+    .spacing(8);
 
     let form_content = column![
         section("Meta", meta_section.into()),
@@ -167,14 +164,14 @@ fn builder_form(app: &Zagel) -> Element<'_, Message> {
         section("Headers", headers::editor(&app.header_rows)),
         section("Auth", auth_view),
     ]
-    .spacing(10);
+    .spacing(8);
 
     let form_scroll = scrollable(form_content)
         .width(Length::Fill)
         .height(Length::Fill);
 
     container(form_scroll)
-        .padding(8)
+        .padding(6)
         .width(Length::Fill)
         .height(Length::Fill)
         .into()
@@ -196,17 +193,22 @@ fn builder_body(app: &Zagel) -> Element<'_, Message> {
                 text_editor(&app.graphql_variables)
                     .on_action(Message::GraphqlVariablesEdited)
                     .height(Length::FillPortion(2));
-            column![text("Query"), query_editor, text("Variables"), vars_editor,]
-                .height(Length::Fill)
-                .spacing(6)
-                .into()
+            column![
+                text("Query").size(12),
+                query_editor,
+                text("Variables").size(12),
+                vars_editor,
+            ]
+            .height(Length::Fill)
+            .spacing(6)
+            .into()
         }
         RequestMode::Rest => {
             let body_editor: iced::widget::TextEditor<'_, _, _, Theme> =
                 text_editor(&app.body_editor)
                     .on_action(Message::BodyEdited)
                     .height(Length::Fill);
-            column![text("Body"), body_editor]
+            column![text("Body").size(12), body_editor]
                 .height(Length::Fill)
                 .spacing(6)
                 .into()
@@ -215,7 +217,7 @@ fn builder_body(app: &Zagel) -> Element<'_, Message> {
 
     let body_section = section(body_title, body_panel);
 
-    container(column![body_section].padding(8).height(Length::Fill))
+    container(column![body_section].padding(6).height(Length::Fill))
         .width(Length::Fill)
         .height(Length::Fill)
         .into()
@@ -226,10 +228,15 @@ fn response(app: &Zagel) -> Element<'_, Message> {
         response_view_toggle(app.response_display),
         response_tab_toggle(app.response_tab),
     ]
-    .spacing(8);
+    .spacing(8)
+    .align_y(Alignment::Center);
 
     if matches!(app.response_tab, super::response::ResponseTab::Body) {
-        status_row = status_row.push(button("Copy raw").on_press(Message::CopyResponseRaw));
+        status_row = status_row.push(
+            button("Copy raw")
+                .on_press(Message::CopyResponseRaw)
+                .padding([5, 10]),
+        );
         if app.response_display == super::response::ResponseDisplay::Pretty
             && app
                 .response
@@ -237,8 +244,11 @@ fn response(app: &Zagel) -> Element<'_, Message> {
                 .and_then(|response| response.body.pretty_text())
                 .is_some()
         {
-            status_row =
-                status_row.push(button("Copy pretty").on_press(Message::CopyResponsePretty));
+            status_row = status_row.push(
+                button("Copy pretty")
+                    .on_press(Message::CopyResponsePretty)
+                    .padding([5, 10]),
+            );
         }
     }
 
@@ -253,13 +263,13 @@ fn response(app: &Zagel) -> Element<'_, Message> {
     let response_section = section(
         "Response",
         column![status_row, response_view]
-            .spacing(6)
+            .spacing(8)
             .height(Length::Fill)
             .into(),
     );
 
     let base = container(response_section)
-        .padding(8)
+        .padding(6)
         .width(Length::Fill)
         .height(Length::Fill)
         .into();
@@ -270,7 +280,7 @@ fn response(app: &Zagel) -> Element<'_, Message> {
             .height(Length::Fill)
             .align_x(alignment::Horizontal::Right)
             .align_y(alignment::Vertical::Top)
-            .padding(12)
+            .padding(16)
             .into();
 
         return stack([base, overlay]).into();
@@ -281,20 +291,23 @@ fn response(app: &Zagel) -> Element<'_, Message> {
 
 fn shortcuts_panel() -> Element<'static, Message> {
     let header = row![
-        text("Keyboard shortcuts").size(16),
-        button("Close").on_press(Message::ToggleShortcutsHelp)
+        text("Keyboard shortcuts").size(14),
+        button("Close")
+            .on_press(Message::ToggleShortcutsHelp)
+            .padding([4, 10])
     ]
-    .spacing(8);
+    .spacing(10)
+    .align_y(Alignment::Center);
 
     let shortcuts = column![
-        text("? - Toggle shortcuts help").size(14),
-        text("Ctrl/Cmd+S - Save request").size(14),
-        text("Ctrl/Cmd+Enter - Send request").size(14),
+        text("?  Toggle shortcuts help").size(13),
+        text("Ctrl/Cmd+S  Save request").size(13),
+        text("Ctrl/Cmd+Enter  Send request").size(13),
     ]
-    .spacing(2);
+    .spacing(4);
 
-    container(column![header, shortcuts].spacing(6))
-        .padding(10)
+    container(column![header, shortcuts].spacing(10))
+        .padding(14)
         .style(theme::overlay_container_style)
         .into()
 }

--- a/src/app/view/workspace.rs
+++ b/src/app/view/workspace.rs
@@ -1,6 +1,7 @@
 use iced::widget::pane_grid::{self, PaneGrid};
 use iced::widget::{
     button, column, container, pick_list, row, scrollable, stack, text, text_editor, text_input,
+    tooltip,
 };
 use iced::{alignment, Alignment, Element, Length, Theme};
 
@@ -9,8 +10,9 @@ use super::auth::auth_editor;
 use super::response::{response_panel, response_tab_toggle, response_view_toggle};
 use super::section;
 use crate::app::options::RequestMode;
+use crate::icons;
 use crate::model::{Method, RequestId};
-use crate::theme;
+use crate::theme::{self, spacing, typo};
 
 #[derive(Debug, Clone, Copy)]
 pub enum WorkspacePane {
@@ -27,7 +29,7 @@ pub enum BuilderPane {
 const ENV_PICK_MAX_WIDTH: f32 = 180.0;
 const MODE_PICK_MAX_WIDTH: f32 = 150.0;
 const METHOD_PICK_MAX_WIDTH: f32 = 120.0;
-const ACTION_WIDTH: f32 = 84.0;
+const ACTION_WIDTH: f32 = 100.0;
 const LABEL_WIDTH: f32 = 72.0;
 
 pub fn workspace(app: &Zagel) -> Element<'_, Message> {
@@ -37,11 +39,11 @@ pub fn workspace(app: &Zagel) -> Element<'_, Message> {
     })
     .width(Length::Fill)
     .height(Length::Fill)
-    .spacing(4.0)
+    .spacing(spacing::XXS)
     .on_resize(6, Message::WorkspacePaneResized);
 
     container(workspace_grid)
-        .padding(6)
+        .padding(spacing::XS)
         .width(Length::Fill)
         .height(Length::Fill)
         .into()
@@ -54,7 +56,7 @@ fn builder(app: &Zagel) -> Element<'_, Message> {
     })
     .width(Length::Fill)
     .height(Length::Fill)
-    .spacing(4.0)
+    .spacing(spacing::XXS)
     .on_resize(6, Message::BuilderPaneResized);
 
     builder_grid.into()
@@ -89,31 +91,31 @@ fn builder_form(app: &Zagel) -> Element<'_, Message> {
 
     let url_input = text_input("https://api.example.com", &app.draft.url)
         .on_input(Message::UrlChanged)
-        .padding(6)
+        .padding(spacing::XS)
         .width(Length::FillPortion(6));
 
     let title_input = text_input("Title", &app.draft.title)
         .on_input(Message::TitleChanged)
-        .padding(6)
+        .padding(spacing::XS)
         .width(Length::FillPortion(5));
 
     let save_path_row: Element<'_, Message> = match app.workspace.selection() {
         Some(RequestId::HttpFile { path, .. }) => row![
-            container(text("Saving to").size(12)).width(Length::Fixed(LABEL_WIDTH)),
-            container(text(path.display().to_string()).size(12)).width(Length::Fill)
+            container(text("Saving to").size(typo::CAPTION)).width(Length::Fixed(LABEL_WIDTH)),
+            container(text(path.display().to_string()).size(typo::CAPTION)).width(Length::Fill)
         ]
         .align_y(Alignment::Center)
-        .spacing(8)
+        .spacing(spacing::SM)
         .into(),
         _ => row![
-            container(text("Save as").size(12)).width(Length::Fixed(LABEL_WIDTH)),
+            container(text("Save as").size(typo::CAPTION)).width(Length::Fixed(LABEL_WIDTH)),
             text_input("path/to/request.http", &app.save_path)
                 .on_input(Message::SavePathChanged)
-                .padding(6)
+                .padding(spacing::XS)
                 .width(Length::Fill),
         ]
         .align_y(Alignment::Center)
-        .spacing(8)
+        .spacing(spacing::SM)
         .into(),
     };
 
@@ -133,45 +135,80 @@ fn builder_form(app: &Zagel) -> Element<'_, Message> {
     let meta_section = column![
         row![
             title_input,
-            button("Save")
+            tooltip(
+                button(
+                    row![
+                        icons::save().size(typo::BODY),
+                        text("Save").size(typo::BODY)
+                    ]
+                    .spacing(spacing::XXS)
+                    .align_y(Alignment::Center),
+                )
                 .on_press(Message::Save)
-                .padding([6, 12])
+                .padding([spacing::XS, spacing::MD])
                 .width(Length::Fixed(ACTION_WIDTH)),
+                "Save request (Ctrl+S)",
+                tooltip::Position::Top,
+            ),
         ]
         .align_y(Alignment::Center)
-        .spacing(8),
+        .spacing(spacing::SM),
         save_path_row,
         row![env_pick, mode_pick]
             .align_y(Alignment::Center)
-            .spacing(8),
+            .spacing(spacing::SM),
     ]
-    .spacing(8);
+    .spacing(spacing::SM);
 
     let request_section = row![
         method_pick,
         url_input,
-        button("Send")
+        tooltip(
+            button(
+                row![
+                    icons::send().size(typo::BODY),
+                    text("Send").size(typo::BODY)
+                ]
+                .spacing(spacing::XXS)
+                .align_y(Alignment::Center),
+            )
             .on_press(Message::Send)
-            .padding([6, 12])
-            .width(Length::Fixed(ACTION_WIDTH)),
+            .padding([spacing::XS, spacing::MD])
+            .width(Length::Fixed(ACTION_WIDTH))
+            .style(theme::accent_button_style),
+            "Send request (Ctrl+Enter)",
+            tooltip::Position::Top,
+        ),
     ]
     .align_y(Alignment::Center)
-    .spacing(8);
+    .spacing(spacing::SM);
 
     let form_content = column![
-        section("Meta", meta_section.into()),
-        section("Request", request_section.into()),
-        section("Headers", headers::editor(&app.header_rows)),
-        section("Auth", auth_view),
+        section(
+            "Meta",
+            icons::info_circle().size(typo::BODY),
+            meta_section.into(),
+        ),
+        section(
+            "Request",
+            icons::send_icon().size(typo::BODY),
+            request_section.into(),
+        ),
+        section(
+            "Headers",
+            icons::list_ul().size(typo::BODY),
+            headers::editor(&app.header_rows),
+        ),
+        section("Auth", icons::key().size(typo::BODY), auth_view,),
     ]
-    .spacing(8);
+    .spacing(spacing::SM);
 
     let form_scroll = scrollable(form_content)
         .width(Length::Fill)
         .height(Length::Fill);
 
     container(form_scroll)
-        .padding(6)
+        .padding(spacing::XS)
         .width(Length::Fill)
         .height(Length::Fill)
         .into()
@@ -194,13 +231,13 @@ fn builder_body(app: &Zagel) -> Element<'_, Message> {
                     .on_action(Message::GraphqlVariablesEdited)
                     .height(Length::FillPortion(2));
             column![
-                text("Query").size(12),
+                text("Query").size(typo::CAPTION),
                 query_editor,
-                text("Variables").size(12),
+                text("Variables").size(typo::CAPTION),
                 vars_editor,
             ]
             .height(Length::Fill)
-            .spacing(6)
+            .spacing(spacing::XS)
             .into()
         }
         RequestMode::Rest => {
@@ -208,19 +245,23 @@ fn builder_body(app: &Zagel) -> Element<'_, Message> {
                 text_editor(&app.body_editor)
                     .on_action(Message::BodyEdited)
                     .height(Length::Fill);
-            column![text("Body").size(12), body_editor]
+            column![text("Body").size(typo::CAPTION), body_editor]
                 .height(Length::Fill)
-                .spacing(6)
+                .spacing(spacing::XS)
                 .into()
         }
     };
 
-    let body_section = section(body_title, body_panel);
+    let body_section = section(body_title, icons::code_slash().size(typo::BODY), body_panel);
 
-    container(column![body_section].padding(6).height(Length::Fill))
-        .width(Length::Fill)
-        .height(Length::Fill)
-        .into()
+    container(
+        column![body_section]
+            .padding(spacing::XS)
+            .height(Length::Fill),
+    )
+    .width(Length::Fill)
+    .height(Length::Fill)
+    .into()
 }
 
 fn response(app: &Zagel) -> Element<'_, Message> {
@@ -228,15 +269,25 @@ fn response(app: &Zagel) -> Element<'_, Message> {
         response_view_toggle(app.response_display),
         response_tab_toggle(app.response_tab),
     ]
-    .spacing(8)
+    .spacing(spacing::SM)
     .align_y(Alignment::Center);
 
     if matches!(app.response_tab, super::response::ResponseTab::Body) {
-        status_row = status_row.push(
-            button("Copy raw")
-                .on_press(Message::CopyResponseRaw)
-                .padding([5, 10]),
-        );
+        status_row = status_row.push(tooltip(
+            button(
+                row![
+                    icons::clipboard().size(typo::BODY),
+                    text("Raw").size(typo::BODY)
+                ]
+                .spacing(spacing::XXS)
+                .align_y(Alignment::Center),
+            )
+            .on_press(Message::CopyResponseRaw)
+            .padding([spacing::XXS, spacing::SM])
+            .style(theme::ghost_button_style),
+            "Copy raw response body",
+            tooltip::Position::Top,
+        ));
         if app.response_display == super::response::ResponseDisplay::Pretty
             && app
                 .response
@@ -244,11 +295,21 @@ fn response(app: &Zagel) -> Element<'_, Message> {
                 .and_then(|response| response.body.pretty_text())
                 .is_some()
         {
-            status_row = status_row.push(
-                button("Copy pretty")
-                    .on_press(Message::CopyResponsePretty)
-                    .padding([5, 10]),
-            );
+            status_row = status_row.push(tooltip(
+                button(
+                    row![
+                        icons::clipboard().size(typo::BODY),
+                        text("Pretty").size(typo::BODY)
+                    ]
+                    .spacing(spacing::XXS)
+                    .align_y(Alignment::Center),
+                )
+                .on_press(Message::CopyResponsePretty)
+                .padding([spacing::XXS, spacing::SM])
+                .style(theme::ghost_button_style),
+                "Copy pretty-printed response",
+                tooltip::Position::Top,
+            ));
         }
     }
 
@@ -262,14 +323,15 @@ fn response(app: &Zagel) -> Element<'_, Message> {
 
     let response_section = section(
         "Response",
+        icons::arrow_left_right().size(typo::BODY),
         column![status_row, response_view]
-            .spacing(8)
+            .spacing(spacing::SM)
             .height(Length::Fill)
             .into(),
     );
 
     let base = container(response_section)
-        .padding(6)
+        .padding(spacing::XS)
         .width(Length::Fill)
         .height(Length::Fill)
         .into();
@@ -280,7 +342,7 @@ fn response(app: &Zagel) -> Element<'_, Message> {
             .height(Length::Fill)
             .align_x(alignment::Horizontal::Right)
             .align_y(alignment::Vertical::Top)
-            .padding(16)
+            .padding(spacing::LG)
             .into();
 
         return stack([base, overlay]).into();
@@ -291,23 +353,32 @@ fn response(app: &Zagel) -> Element<'_, Message> {
 
 fn shortcuts_panel() -> Element<'static, Message> {
     let header = row![
-        text("Keyboard shortcuts").size(14),
-        button("Close")
-            .on_press(Message::ToggleShortcutsHelp)
-            .padding([4, 10])
+        icons::question_circle().size(typo::HEADING),
+        text("Keyboard shortcuts").size(typo::HEADING),
+        button(
+            row![
+                icons::x_circle().size(typo::BODY),
+                text("Close").size(typo::BODY)
+            ]
+            .spacing(spacing::XXS)
+            .align_y(Alignment::Center),
+        )
+        .on_press(Message::ToggleShortcutsHelp)
+        .padding([spacing::XXS, spacing::SM])
+        .style(theme::ghost_button_style),
     ]
-    .spacing(10)
+    .spacing(spacing::SM)
     .align_y(Alignment::Center);
 
     let shortcuts = column![
-        text("?  Toggle shortcuts help").size(13),
-        text("Ctrl/Cmd+S  Save request").size(13),
-        text("Ctrl/Cmd+Enter  Send request").size(13),
+        text("?  Toggle shortcuts help").size(typo::BODY),
+        text("Ctrl/Cmd+S  Save request").size(typo::BODY),
+        text("Ctrl/Cmd+Enter  Send request").size(typo::BODY),
     ]
-    .spacing(4);
+    .spacing(spacing::XXS);
 
-    container(column![header, shortcuts].spacing(10))
-        .padding(14)
+    container(column![header, shortcuts].spacing(spacing::SM))
+        .padding(spacing::LG)
         .style(theme::overlay_container_style)
         .into()
 }

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -1,0 +1,162 @@
+//! Centralized icon helpers using Bootstrap Icons via `iced_fonts`.
+//!
+//! All icon usage across the app should go through this module so that
+//! swapping icon sets later is a single-file change.
+
+use iced::widget::Text;
+
+// Re-export frequently used icons under app-domain names.
+// The underlying `iced_fonts::bootstrap::*` functions each return a
+// `Text` widget pre-configured with the Bootstrap icon font.
+
+/// Chevron-right: collapsed collection indicator.
+pub fn chevron_right<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::chevron_right()
+}
+
+/// Chevron-down: expanded collection indicator.
+pub fn chevron_down<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::chevron_down()
+}
+
+/// Check-square-fill: checked checkbox in edit mode.
+pub fn check_square<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::check_square_fill()
+}
+
+/// Square: unchecked checkbox in edit mode.
+pub fn square<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::square()
+}
+
+/// Arrow-up: move item up in edit mode.
+pub fn arrow_up<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::arrow_up()
+}
+
+/// Arrow-down: move item down in edit mode.
+pub fn arrow_down<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::arrow_down()
+}
+
+/// Arrow-right: selected item indicator.
+pub fn arrow_right<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::arrow_right()
+}
+
+/// Plus-circle: add item.
+pub fn plus_circle<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::plus_circle()
+}
+
+/// Trash: delete item.
+pub fn trash<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::trash()
+}
+
+/// Pencil-square: edit mode toggle.
+pub fn pencil<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::pencil_square()
+}
+
+/// Check-lg: done / confirm.
+pub fn check_lg<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::check_lg()
+}
+
+/// Send-fill: send request.
+pub fn send<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::send_fill()
+}
+
+/// Floppy: save.
+pub fn save<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::floppy()
+}
+
+/// X-lg: close / remove.
+pub fn x_lg<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::x_lg()
+}
+
+/// Plus-lg: add header.
+pub fn plus_lg<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::plus_lg()
+}
+
+/// Clipboard: copy.
+pub fn clipboard<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::clipboard()
+}
+
+/// Folder2-open: project folder.
+pub fn folder_open<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::foldertwo_open()
+}
+
+/// Globe2: global environment.
+pub fn globe<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::globe()
+}
+
+/// Collection: collections section.
+pub fn collection<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::collection()
+}
+
+/// Question-circle: help / shortcuts.
+pub fn question_circle<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::question_circle()
+}
+
+/// X-circle: close overlay.
+pub fn x_circle<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::x_circle()
+}
+
+/// Dash-circle: remove project/env root.
+pub fn dash_circle<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::dash_circle()
+}
+
+/// Hourglass-split: loading / in-flight request.
+#[allow(dead_code)]
+pub fn hourglass<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::hourglass_split()
+}
+
+/// Lock-fill: secure/password field indicator.
+#[allow(dead_code)]
+pub fn lock<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::lock_fill()
+}
+
+/// Key-fill: auth section icon.
+pub fn key<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::key_fill()
+}
+
+/// Info-circle: meta section icon.
+pub fn info_circle<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::info_circle()
+}
+
+/// Send (outline): request section icon.
+pub fn send_icon<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::send()
+}
+
+/// List-ul: headers section icon.
+pub fn list_ul<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::list_ul()
+}
+
+/// Code-slash: body section icon.
+pub fn code_slash<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::code_slash()
+}
+
+/// Arrow-left-right: response section icon.
+pub fn arrow_left_right<'a>() -> Text<'a> {
+    iced_fonts::bootstrap::arrow_left_right()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 
 mod app;
 mod cli;
+mod icons;
 mod launch;
 mod model;
 mod net;

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,5 +1,5 @@
 use iced::widget::container;
-use iced::{border, Theme};
+use iced::{border, Color, Theme};
 use iced_highlighter::Theme as HighlightTheme;
 use serde::{Deserialize, Serialize};
 
@@ -38,6 +38,45 @@ pub fn overlay_container_style(theme: &Theme) -> container::Style {
         border: border::rounded(8.0)
             .width(1.0)
             .color(palette.background.strong.color),
+        ..container::Style::default()
+    }
+}
+
+/// A card-like section container with rounded corners and a subtle border.
+pub fn section_container_style(theme: &Theme) -> container::Style {
+    let palette = theme.extended_palette();
+
+    container::Style {
+        background: Some(palette.background.weak.color.into()),
+        text_color: Some(palette.background.weak.text),
+        border: border::rounded(6.0)
+            .width(1.0)
+            .color(palette.background.strong.color),
+        ..container::Style::default()
+    }
+}
+
+/// Status bar container style with a subtle top-tinted background.
+pub fn status_bar_style(theme: &Theme) -> container::Style {
+    let palette = theme.extended_palette();
+    let bg = palette.background.strong.color;
+    container::Style {
+        background: Some(Color::from_rgba(bg.r, bg.g, bg.b, 0.5).into()),
+        text_color: Some(palette.background.weak.text),
+        border: border::rounded(0.0),
+        ..container::Style::default()
+    }
+}
+
+/// Sidebar panel background — slightly darker for visual separation.
+pub fn sidebar_container_style(theme: &Theme) -> container::Style {
+    let palette = theme.extended_palette();
+    let bg = palette.background.strong.color;
+
+    container::Style {
+        background: Some(Color::from_rgba(bg.r, bg.g, bg.b, 0.25).into()),
+        text_color: None,
+        border: border::rounded(0.0),
         ..container::Style::default()
     }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -9,7 +9,7 @@ use crate::model::Method;
 // Design tokens — Cosmic DE-inspired spacing & corner-radius system
 // ---------------------------------------------------------------------------
 
-/// Spacing tokens (px): 4 / 8 / 12 / 16 / 24 / 32.
+/// Spacing tokens (px): 2 / 4 / 6 / 8 / 12 / 16 / 24 / 32.
 #[allow(dead_code)]
 pub mod spacing {
     pub const XXXS: f32 = 2.0;

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,7 +1,79 @@
-use iced::widget::container;
+use iced::widget::{button, container};
 use iced::{border, Color, Theme};
 use iced_highlighter::Theme as HighlightTheme;
 use serde::{Deserialize, Serialize};
+
+use crate::model::Method;
+
+// ---------------------------------------------------------------------------
+// Design tokens — Cosmic DE-inspired spacing & corner-radius system
+// ---------------------------------------------------------------------------
+
+/// Spacing tokens (px): 4 / 8 / 12 / 16 / 24 / 32.
+#[allow(dead_code)]
+pub mod spacing {
+    pub const XXXS: f32 = 2.0;
+    pub const XXS: f32 = 4.0;
+    pub const XS: f32 = 6.0;
+    pub const SM: f32 = 8.0;
+    pub const MD: f32 = 12.0;
+    pub const LG: f32 = 16.0;
+    pub const XL: f32 = 24.0;
+    pub const XXL: f32 = 32.0;
+}
+
+/// Corner-radius tokens following Cosmic DE conventions.
+#[allow(dead_code)]
+pub mod radius {
+    pub const NONE: f32 = 0.0;
+    pub const XS: f32 = 4.0;
+    pub const SM: f32 = 6.0;
+    pub const MD: f32 = 8.0;
+    pub const LG: f32 = 12.0;
+    pub const PILL: f32 = 160.0;
+}
+
+/// Typography scale.
+pub mod typo {
+    pub const CAPTION: f32 = 11.0;
+    pub const BODY: f32 = 13.0;
+    pub const HEADING: f32 = 14.0;
+    pub const TITLE: f32 = 16.0;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP method colors (Postman-inspired)
+// ---------------------------------------------------------------------------
+
+/// Returns the badge color for an HTTP method.
+pub const fn method_color(method: Method) -> Color {
+    match method {
+        Method::Get | Method::Head => Color::from_rgb(0.38, 0.82, 0.37), // #61D15F green
+        Method::Post => Color::from_rgb(0.94, 0.68, 0.31),               // #F0AD4E amber
+        Method::Put => Color::from_rgb(0.29, 0.56, 0.85),                // #4A90D9 blue
+        Method::Patch => Color::from_rgb(0.69, 0.49, 0.86),              // #B07CDC purple
+        Method::Delete => Color::from_rgb(0.90, 0.22, 0.21),             // #E53935 red
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Response status-code colors
+// ---------------------------------------------------------------------------
+
+/// Returns a color for an HTTP status code.
+pub const fn status_color(code: u16) -> Color {
+    match code {
+        200..=299 => Color::from_rgb(0.38, 0.82, 0.37), // 2xx = green
+        300..=399 => Color::from_rgb(0.94, 0.68, 0.31), // 3xx = amber
+        400..=499 => Color::from_rgb(0.90, 0.22, 0.21), // 4xx = red
+        500..=599 => Color::from_rgb(0.85, 0.16, 0.16), // 5xx = darker red
+        _ => Color::from_rgb(0.63, 0.63, 0.63),         // unknown = grey
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Theme choice
+// ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
@@ -29,13 +101,17 @@ impl ThemeChoice {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Container styles
+// ---------------------------------------------------------------------------
+
 pub fn overlay_container_style(theme: &Theme) -> container::Style {
     let palette = theme.extended_palette();
 
     container::Style {
         background: Some(palette.background.weak.color.into()),
         text_color: Some(palette.background.weak.text),
-        border: border::rounded(8.0)
+        border: border::rounded(radius::MD)
             .width(1.0)
             .color(palette.background.strong.color),
         ..container::Style::default()
@@ -49,7 +125,7 @@ pub fn section_container_style(theme: &Theme) -> container::Style {
     container::Style {
         background: Some(palette.background.weak.color.into()),
         text_color: Some(palette.background.weak.text),
-        border: border::rounded(6.0)
+        border: border::rounded(radius::SM)
             .width(1.0)
             .color(palette.background.strong.color),
         ..container::Style::default()
@@ -63,7 +139,7 @@ pub fn status_bar_style(theme: &Theme) -> container::Style {
     container::Style {
         background: Some(Color::from_rgba(bg.r, bg.g, bg.b, 0.5).into()),
         text_color: Some(palette.background.weak.text),
-        border: border::rounded(0.0),
+        border: border::rounded(radius::NONE),
         ..container::Style::default()
     }
 }
@@ -76,7 +152,263 @@ pub fn sidebar_container_style(theme: &Theme) -> container::Style {
     container::Style {
         background: Some(Color::from_rgba(bg.r, bg.g, bg.b, 0.25).into()),
         text_color: None,
-        border: border::rounded(0.0),
+        border: border::rounded(radius::NONE),
         ..container::Style::default()
+    }
+}
+
+/// Section title color derived from the current theme palette.
+#[allow(dead_code)]
+pub fn section_title_color(theme: &Theme) -> Color {
+    let palette = theme.extended_palette();
+    let txt = palette.background.weak.text;
+    // Slightly dimmed version of the weak text color
+    Color::from_rgba(txt.r, txt.g, txt.b, 0.7)
+}
+
+// ---------------------------------------------------------------------------
+// Button styles — closures compatible with `button.style(fn)`
+// ---------------------------------------------------------------------------
+
+/// Accent / CTA button (e.g. Send). Prominent filled style.
+pub fn accent_button_style(theme: &Theme, status: button::Status) -> button::Style {
+    let palette = theme.extended_palette();
+    let accent = palette.primary.strong;
+
+    match status {
+        button::Status::Active => button::Style {
+            background: Some(accent.color.into()),
+            text_color: accent.text,
+            border: border::rounded(radius::SM),
+            ..button::Style::default()
+        },
+        button::Status::Hovered => {
+            let c = accent.color;
+            let lighter = Color::from_rgba(
+                (c.r + 0.08).min(1.0),
+                (c.g + 0.08).min(1.0),
+                (c.b + 0.08).min(1.0),
+                1.0,
+            );
+            button::Style {
+                background: Some(lighter.into()),
+                text_color: accent.text,
+                border: border::rounded(radius::SM),
+                ..button::Style::default()
+            }
+        }
+        button::Status::Pressed => {
+            let c = accent.color;
+            let darker = Color::from_rgba(
+                (c.r - 0.06).max(0.0),
+                (c.g - 0.06).max(0.0),
+                (c.b - 0.06).max(0.0),
+                1.0,
+            );
+            button::Style {
+                background: Some(darker.into()),
+                text_color: accent.text,
+                border: border::rounded(radius::SM),
+                ..button::Style::default()
+            }
+        }
+        button::Status::Disabled => button::Style {
+            background: Some(
+                Color::from_rgba(accent.color.r, accent.color.g, accent.color.b, 0.4).into(),
+            ),
+            text_color: Color::from_rgba(accent.text.r, accent.text.g, accent.text.b, 0.5),
+            border: border::rounded(radius::SM),
+            ..button::Style::default()
+        },
+    }
+}
+
+/// Destructive button (e.g. Delete). Red-tinted style.
+pub fn destructive_button_style(theme: &Theme, status: button::Status) -> button::Style {
+    let palette = theme.extended_palette();
+    let danger = palette.danger.strong;
+
+    match status {
+        button::Status::Active => button::Style {
+            background: Some(danger.color.into()),
+            text_color: danger.text,
+            border: border::rounded(radius::SM),
+            ..button::Style::default()
+        },
+        button::Status::Hovered => {
+            let c = danger.color;
+            let lighter = Color::from_rgba(
+                (c.r + 0.08).min(1.0),
+                (c.g + 0.08).min(1.0),
+                (c.b + 0.08).min(1.0),
+                1.0,
+            );
+            button::Style {
+                background: Some(lighter.into()),
+                text_color: danger.text,
+                border: border::rounded(radius::SM),
+                ..button::Style::default()
+            }
+        }
+        button::Status::Pressed => {
+            let c = danger.color;
+            let darker = Color::from_rgba(
+                (c.r - 0.06).max(0.0),
+                (c.g - 0.06).max(0.0),
+                (c.b - 0.06).max(0.0),
+                1.0,
+            );
+            button::Style {
+                background: Some(darker.into()),
+                text_color: danger.text,
+                border: border::rounded(radius::SM),
+                ..button::Style::default()
+            }
+        }
+        button::Status::Disabled => button::Style {
+            background: Some(
+                Color::from_rgba(danger.color.r, danger.color.g, danger.color.b, 0.4).into(),
+            ),
+            text_color: Color::from_rgba(danger.text.r, danger.text.g, danger.text.b, 0.5),
+            border: border::rounded(radius::SM),
+            ..button::Style::default()
+        },
+    }
+}
+
+/// Ghost / icon-only button — transparent background, visible on hover.
+pub fn ghost_button_style(theme: &Theme, status: button::Status) -> button::Style {
+    let palette = theme.extended_palette();
+    let txt = palette.background.base.text;
+
+    match status {
+        button::Status::Active => button::Style {
+            background: None,
+            text_color: txt,
+            border: border::rounded(radius::XS),
+            ..button::Style::default()
+        },
+        button::Status::Hovered => {
+            let bg = palette.background.weak.color;
+            button::Style {
+                background: Some(Color::from_rgba(bg.r, bg.g, bg.b, 0.3).into()),
+                text_color: txt,
+                border: border::rounded(radius::XS),
+                ..button::Style::default()
+            }
+        }
+        button::Status::Pressed => {
+            let bg = palette.background.weak.color;
+            button::Style {
+                background: Some(Color::from_rgba(bg.r, bg.g, bg.b, 0.5).into()),
+                text_color: txt,
+                border: border::rounded(radius::XS),
+                ..button::Style::default()
+            }
+        }
+        button::Status::Disabled => button::Style {
+            background: None,
+            text_color: Color::from_rgba(txt.r, txt.g, txt.b, 0.3),
+            border: border::rounded(radius::XS),
+            ..button::Style::default()
+        },
+    }
+}
+
+/// Sidebar tree-item button — subtle background, highlight on hover/selected.
+pub fn sidebar_item_style(theme: &Theme, status: button::Status, selected: bool) -> button::Style {
+    let palette = theme.extended_palette();
+
+    if selected {
+        let accent = palette.primary.weak;
+        return match status {
+            button::Status::Active | button::Status::Pressed => button::Style {
+                background: Some(accent.color.into()),
+                text_color: accent.text,
+                border: border::rounded(radius::XS),
+                ..button::Style::default()
+            },
+            button::Status::Hovered => {
+                let c = accent.color;
+                let brighter = Color::from_rgba(
+                    (c.r + 0.05).min(1.0),
+                    (c.g + 0.05).min(1.0),
+                    (c.b + 0.05).min(1.0),
+                    1.0,
+                );
+                button::Style {
+                    background: Some(brighter.into()),
+                    text_color: accent.text,
+                    border: border::rounded(radius::XS),
+                    ..button::Style::default()
+                }
+            }
+            button::Status::Disabled => button::Style {
+                background: Some(accent.color.into()),
+                text_color: Color::from_rgba(accent.text.r, accent.text.g, accent.text.b, 0.5),
+                border: border::rounded(radius::XS),
+                ..button::Style::default()
+            },
+        };
+    }
+
+    // Unselected
+    let txt = palette.background.base.text;
+    match status {
+        button::Status::Active => button::Style {
+            background: None,
+            text_color: txt,
+            border: border::rounded(radius::XS),
+            ..button::Style::default()
+        },
+        button::Status::Hovered => {
+            let bg = palette.background.weak.color;
+            button::Style {
+                background: Some(Color::from_rgba(bg.r, bg.g, bg.b, 0.35).into()),
+                text_color: txt,
+                border: border::rounded(radius::XS),
+                ..button::Style::default()
+            }
+        }
+        button::Status::Pressed => {
+            let bg = palette.background.weak.color;
+            button::Style {
+                background: Some(Color::from_rgba(bg.r, bg.g, bg.b, 0.55).into()),
+                text_color: txt,
+                border: border::rounded(radius::XS),
+                ..button::Style::default()
+            }
+        }
+        button::Status::Disabled => button::Style {
+            background: None,
+            text_color: Color::from_rgba(txt.r, txt.g, txt.b, 0.3),
+            border: border::rounded(radius::XS),
+            ..button::Style::default()
+        },
+    }
+}
+
+/// Method badge button — colored background based on HTTP method.
+#[allow(dead_code)]
+pub fn method_badge_style(method: Method) -> impl Fn(&Theme, button::Status) -> button::Style {
+    move |_theme, status| {
+        let color = method_color(method);
+        let bg_alpha = match status {
+            button::Status::Active => 0.18,
+            button::Status::Hovered => 0.28,
+            button::Status::Pressed => 0.35,
+            button::Status::Disabled => 0.08,
+        };
+        let text_alpha = if matches!(status, button::Status::Disabled) {
+            0.5
+        } else {
+            1.0
+        };
+        button::Style {
+            background: Some(Color::from_rgba(color.r, color.g, color.b, bg_alpha).into()),
+            text_color: Color::from_rgba(color.r, color.g, color.b, text_alpha),
+            border: border::rounded(radius::XS),
+            ..button::Style::default()
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Add card-like section containers with rounded corners and subtle borders for visual grouping (Projects, Global Envs, Collections, Meta, Request, Headers, Auth, Response)
- Introduce distinct sidebar background and semi-transparent status bar styling via 3 new container styles in `theme.rs`
- Tighten pane grid spacing (8px -> 2px) and standardize text sizing, button padding, and alignment across all panels (sidebar, workspace builder, response, headers editor, auth editor)

## Changes

| File | What changed |
|------|-------------|
| `src/theme.rs` | Added `section_container_style`, `status_bar_style`, `sidebar_container_style` |
| `src/app/view/mod.rs` | Updated `section()` helper to use card-style containers, smaller section titles, tighter pane spacing, styled status bar |
| `src/app/view/sidebar.rs` | Increased indent, applied sidebar background, improved button/text sizing and alignment |
| `src/app/view/workspace.rs` | Removed redundant header, reduced padding, standardized button/input sizing |
| `src/app/view/response.rs` | Improved tab toggle sizing and section spacing |
| `src/app/view/auth.rs` | Standardized input padding and spacing |
| `src/app/headers.rs` | Fixed cross-platform button text, improved row alignment and padding |

All changes pass `cargo clippy --all-targets --all-features -- -D warnings`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable icon set with Bootstrap icons and ASCII mode.
  * Automated screenshot publishing to pull request comments.

* **Improvements**
  * Unified spacing, typography and token-driven styling across the UI.
  * Updated header editor, sidebar, workspace and response panels with refined layouts, icons and tooltips.
  * New themed button and container styles for clearer visual hierarchy.

* **Bug Fixes**
  * Graceful handling when screenshots arrive after an automation run completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->